### PR TITLE
Dockerfile: add rsync to list of installed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get install -y -q \
     linux-libc-dev \
     make \
     patch \
+    rsync \
     s3cmd \
     sed \
     subversion \


### PR DESCRIPTION
`rsync` is required for installing kernel headers.
Let's make it available inside the container.

With this patch both GCC `10.2.0` RISC-V toolchains (`riscv64` and `riscv32`) can be
successfully built inside the docker container, specified by the `Dockerfile`.

Fixes https://github.com/compiler-explorer/compiler-explorer/issues/965 
Related to https://github.com/compiler-explorer/gcc-cross-builder/pull/5