### PR TITLE
compiler-explorer: Add workaround for isl missing

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -43,6 +43,10 @@ done
 
 cp "${CONFIG_FILE}" .config
 ${CT} oldconfig
+# oldconfig will restore mirror urls, so as a workaround until
+# https://github.com/crosstool-ng/crosstool-ng/issues/1609 gets
+# fixed we have to update the mirror url after calling oldconfig
+sed -i -r 's|CT_ISL_MIRRORS=".*"|CT_ISL_MIRRORS="https://libisl.sourceforge.io/"|g' .config
 ${CT} "build.$(nproc)"
 
 export XZ_DEFAULTS="-T 0"

--- a/build/latest/arm-7.5.0.config
+++ b/build/latest/arm-7.5.0.config
@@ -529,28 +529,28 @@ CT_GCC_PKG_NAME="gcc"
 CT_GCC_SRC_RELEASE=y
 # CT_GCC_SRC_DEVEL is not set
 CT_GCC_PATCH_ORDER="global"
-CT_GCC_V_11=y
+# CT_GCC_V_11 is not set
 # CT_GCC_V_10 is not set
 # CT_GCC_V_9 is not set
 # CT_GCC_V_8 is not set
-# CT_GCC_V_7 is not set
+CT_GCC_V_7=y
 # CT_GCC_V_6 is not set
 # CT_GCC_V_5 is not set
 # CT_GCC_V_4_9 is not set
-CT_GCC_VERSION="11.2.0"
+CT_GCC_VERSION="7.5.0"
 CT_GCC_MIRRORS="$(CT_Mirrors GNU gcc/gcc-${CT_GCC_VERSION}) $(CT_Mirrors sourceware gcc/releases/gcc-${CT_GCC_VERSION})"
 CT_GCC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GCC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_GCC_ARCHIVE_FORMATS=".tar.xz .tar.gz"
 CT_GCC_SIGNATURE_FORMAT=""
-CT_GCC_later_than_11=y
-CT_GCC_11_or_later=y
-CT_GCC_later_than_10=y
-CT_GCC_10_or_later=y
-CT_GCC_later_than_9=y
-CT_GCC_9_or_later=y
-CT_GCC_later_than_8=y
-CT_GCC_8_or_later=y
+CT_GCC_11_or_older=y
+CT_GCC_older_than_11=y
+CT_GCC_10_or_older=y
+CT_GCC_older_than_10=y
+CT_GCC_9_or_older=y
+CT_GCC_older_than_9=y
+CT_GCC_8_or_older=y
+CT_GCC_older_than_8=y
 CT_GCC_later_than_7=y
 CT_GCC_7_or_later=y
 CT_GCC_later_than_6=y
@@ -589,7 +589,6 @@ CT_CC_GCC_ENABLE_TARGET_OPTSPACE=y
 # Misc. obscure options.
 #
 CT_CC_CXA_ATEXIT=y
-CT_CC_GCC_TM_CLONE_REGISTRY=m
 # CT_CC_GCC_DISABLE_PCH is not set
 CT_CC_GCC_SJLJ_EXCEPTIONS=m
 CT_CC_GCC_LDBL_128=m

--- a/build/latest/arm64-7.5.0.config
+++ b/build/latest/arm64-7.5.0.config
@@ -513,28 +513,28 @@ CT_GCC_PKG_NAME="gcc"
 CT_GCC_SRC_RELEASE=y
 # CT_GCC_SRC_DEVEL is not set
 CT_GCC_PATCH_ORDER="global"
-CT_GCC_V_11=y
+# CT_GCC_V_11 is not set
 # CT_GCC_V_10 is not set
 # CT_GCC_V_9 is not set
 # CT_GCC_V_8 is not set
-# CT_GCC_V_7 is not set
+CT_GCC_V_7=y
 # CT_GCC_V_6 is not set
 # CT_GCC_V_5 is not set
 # CT_GCC_V_4_9 is not set
-CT_GCC_VERSION="11.2.0"
+CT_GCC_VERSION="7.5.0"
 CT_GCC_MIRRORS="$(CT_Mirrors GNU gcc/gcc-${CT_GCC_VERSION}) $(CT_Mirrors sourceware gcc/releases/gcc-${CT_GCC_VERSION})"
 CT_GCC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GCC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_GCC_ARCHIVE_FORMATS=".tar.xz .tar.gz"
 CT_GCC_SIGNATURE_FORMAT=""
-CT_GCC_later_than_11=y
-CT_GCC_11_or_later=y
-CT_GCC_later_than_10=y
-CT_GCC_10_or_later=y
-CT_GCC_later_than_9=y
-CT_GCC_9_or_later=y
-CT_GCC_later_than_8=y
-CT_GCC_8_or_later=y
+CT_GCC_11_or_older=y
+CT_GCC_older_than_11=y
+CT_GCC_10_or_older=y
+CT_GCC_older_than_10=y
+CT_GCC_9_or_older=y
+CT_GCC_older_than_9=y
+CT_GCC_8_or_older=y
+CT_GCC_older_than_8=y
 CT_GCC_later_than_7=y
 CT_GCC_7_or_later=y
 CT_GCC_later_than_6=y
@@ -573,7 +573,6 @@ CT_CC_GCC_ENABLE_TARGET_OPTSPACE=y
 # Misc. obscure options.
 #
 CT_CC_CXA_ATEXIT=y
-CT_CC_GCC_TM_CLONE_REGISTRY=m
 # CT_CC_GCC_DISABLE_PCH is not set
 CT_CC_GCC_SJLJ_EXCEPTIONS=m
 CT_CC_GCC_LDBL_128=m


### PR DESCRIPTION
Hi All,

This adds a workaround for another crosstool issue [1]
where the mirror they use for isl has gone down.

As of this moment there doesn't seem to be another official
mirror yet so this changes it to point to an unofficial mirror.

Unfortunately calling olddefconfig like ./build.sh does will
restore the old mirror, so we have to update it after the call.

This also fixes a typo in the 7.5.0 files which were accidentally
set to build 11.2.0

[1] https://github.com/crosstool-ng/crosstool-ng/issues/1609