### PR TITLE
[compiler-explorer] Add zlib-dev as new dependency of binutils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update -y -q && apt-get upgrade -y -q && apt-get upgrade -y -q && \
     autopoint \
     gettext \
     vim \
+    zlib1g-dev \
     xz-utils && \
     cd /tmp && \
     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \


### PR DESCRIPTION
Hi All,

binutils seems to have added a dependency on zlib for building and so the nightly builds
have been failing.

This adds the zlib-dev package to the docker image so we can build the arm and arm64
nightlies again.

Thanks,
Tamar