### PR TITLE
compiler-explorer: fix incorrect GCC 11 usage.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,6 @@ RUN apt-get update -y -q && apt-get upgrade -y -q && apt-get upgrade -y -q && \
     flex \
     git \
     gawk \
-    gcc \
-    g++ \
     binutils-multiarch \
     gperf \
     help2man \
@@ -42,18 +40,20 @@ RUN apt-get update -y -q && apt-get upgrade -y -q && apt-get upgrade -y -q && \
     gettext \
     vim \
     zlib1g-dev \
+    software-properties-common \
     xz-utils && \
     cd /tmp && \
     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install && \
-    rm -rf aws* && \
-    cd /opt && \
-    curl "https://compiler-explorer.s3.amazonaws.com/opt/gcc-11.2.0.tar.xz" -o gcc11.tar.xz && \
-    tar Jxvf gcc11.tar.xz && \
-    rm gcc11.tar.xz
+    rm -rf aws*
 
-ENV PATH="/opt/gcc-11.2.0/bin:${PATH}"
+# Install GCC 11 from the Ubuntu test repository
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
+    apt-get update && \
+    apt-get install -y -q gcc-11 g++-11 gnat-11 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 60 --slave /usr/bin/g++ g++ /usr/bin/g++-11 && \
+    update-alternatives --config gcc
 
 WORKDIR /opt
 COPY build/patches/cross-tool-ng/cross-tool-ng-1.22.0.patch ./

--- a/build/build.sh
+++ b/build/build.sh
@@ -61,7 +61,7 @@ fi
 
 
 cp "${CONFIG_FILE}" .config
-${CT} oldconfig
+${CT} olddefconfig
 # oldconfig will restore mirror urls, so as a workaround until
 # https://github.com/crosstool-ng/crosstool-ng/issues/1609 gets
 # fixed we have to update the mirror url after calling oldconfig


### PR DESCRIPTION
Hi All,

#15 added the use of GCC 11.2 to compile toolchains with without setting the
loader path to use that GCC's libstdc++.  As a result the produced
cross compiler may use features from a libstdc++ that it doesn't know how to
find at runtime.

The arm nighties are failing[0] because of this as the stage-1 compiler is
unable to find the right GLIBCXX:

```
./xgcc: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.26' not found (required by ./xgcc)
```

Normally you fix this by setting `LD_LIBRARY_PATH`, however crosstools-ng
immediately errors out here as it explicitly checks that you don't set
`LD_LIBRARY_PATH`.

It's however unclear to me why 11.2 is required, given that the GCC pre-reqs say
that GCC 5.1 is the minimum[1].  The only thing that is really required is a gnat
compiler, which can just be installed from the Ubuntu repo.

In any case, this removes the custom GCC 11.2 and installs GCC 11 from Ubuntu's
test repos.

I've tested arm, mips and ppc64 and all work fine now.

Secondly I've changed the crosstool's `oldconfig` to `olddefconfig` since we're
running these non-interactively. `oldconfig` waits for user input, but it works
atm because the terminal errors out:

```
  Error in reading or end of file.
  
  * Restart config...
  *
  *
  * Operating System
  Error in reading or end of file.
```

which gets it to accept the default values, which is what `olddefconfig` does
already.

Fixes #13 

Kind Regards,
Tamar

[0] https://github.com/compiler-explorer/compiler-workflows/actions/workflows//build-daily-arm32.yml
[1] https://gcc.gnu.org/install/prerequisites.html