### PR TITLE
Revert previous bump in ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 MAINTAINER Matt Godbolt <matt@godbolt.org>
 
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Our dockerimage is using different versions of crosstool-ng.
Old version don't handle bash >= 4, so we can't simply bump
the version without breaking things.

The GCC 11 issue has been fixed differently in the meantime,
so the bump is not even needed now.

fixes #24

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>