### PR TITLE
Fix GNAT from GCC 11.2.0 for PPC64

### DIFF
--- a/build/latest/powerpc64-11.2.0.config
+++ b/build/latest/powerpc64-11.2.0.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# crosstool-NG 1.24.0.504_6737cfa Configuration
+# crosstool-NG 1.25.0.26_db6f703 Configuration
 #
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_cxx11=y
@@ -28,11 +28,11 @@ CT_CONFIGURE_has_sha1sum=y
 CT_CONFIGURE_has_sha256sum=y
 CT_CONFIGURE_has_sha512sum=y
 CT_CONFIGURE_has_install_with_strip_program=y
-CT_VERSION="1.24.0.504_6737cfa"
+CT_VERSION="1.25.0.26_db6f703"
 CT_VCHECK=""
-CT_CONFIG_VERSION_ENV="3"
-CT_CONFIG_VERSION_CURRENT="3"
-CT_CONFIG_VERSION="3"
+CT_CONFIG_VERSION_ENV="4"
+CT_CONFIG_VERSION_CURRENT="4"
+CT_CONFIG_VERSION="4"
 CT_MODULES=y
 
 #
@@ -280,6 +280,8 @@ CT_LINUX_PATCH_GLOBAL=y
 # CT_LINUX_PATCH_LOCAL_BUNDLED is not set
 # CT_LINUX_PATCH_NONE is not set
 CT_LINUX_PATCH_ORDER="global"
+# CT_LINUX_V_5_17 is not set
+# CT_LINUX_V_5_16 is not set
 CT_LINUX_V_5_15=y
 # CT_LINUX_V_5_14 is not set
 # CT_LINUX_V_5_13 is not set
@@ -314,12 +316,16 @@ CT_LINUX_V_5_15=y
 # CT_LINUX_V_3_10 is not set
 # CT_LINUX_V_3_4 is not set
 # CT_LINUX_V_3_2 is not set
-CT_LINUX_VERSION="5.15.2"
+CT_LINUX_VERSION="5.15.37"
 CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
 CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_FORMATS=".tar.xz .tar.gz"
 CT_LINUX_SIGNATURE_FORMAT="unpacked/.sign"
+CT_LINUX_later_than_5_12=y
+CT_LINUX_5_12_or_later=y
+CT_LINUX_later_than_5_5=y
+CT_LINUX_5_5_or_later=y
 CT_LINUX_later_than_5_3=y
 CT_LINUX_5_3_or_later=y
 CT_LINUX_later_than_4_8=y
@@ -334,7 +340,6 @@ CT_KERNEL_LINUX_VERBOSITY_0=y
 # CT_KERNEL_LINUX_VERBOSITY_1 is not set
 # CT_KERNEL_LINUX_VERBOSITY_2 is not set
 CT_KERNEL_LINUX_VERBOSE_LEVEL=0
-CT_KERNEL_LINUX_INSTALL_CHECK=y
 CT_ALL_KERNEL_CHOICES="BARE_METAL LINUX WINDOWS"
 
 #
@@ -372,6 +377,7 @@ CT_BINUTILS_PATCH_GLOBAL=y
 # CT_BINUTILS_PATCH_LOCAL_BUNDLED is not set
 # CT_BINUTILS_PATCH_NONE is not set
 CT_BINUTILS_PATCH_ORDER="global"
+# CT_BINUTILS_V_2_38 is not set
 CT_BINUTILS_V_2_37=y
 # CT_BINUTILS_V_2_36 is not set
 # CT_BINUTILS_V_2_35 is not set
@@ -417,10 +423,9 @@ CT_ALL_BINUTILS_CHOICES="BINUTILS"
 #
 CT_LIBC_GLIBC=y
 # CT_LIBC_MUSL is not set
-# CT_LIBC_UCLIBC is not set
+# CT_LIBC_UCLIBC_NG is not set
 CT_LIBC="glibc"
 CT_LIBC_CHOICE_KSYM="GLIBC"
-CT_THREADS="nptl"
 CT_LIBC_GLIBC_SHOW=y
 
 #
@@ -442,6 +447,7 @@ CT_GLIBC_PATCH_GLOBAL=y
 # CT_GLIBC_PATCH_LOCAL_BUNDLED is not set
 # CT_GLIBC_PATCH_NONE is not set
 CT_GLIBC_PATCH_ORDER="global"
+# CT_GLIBC_V_2_35 is not set
 CT_GLIBC_V_2_34=y
 # CT_GLIBC_V_2_33 is not set
 # CT_GLIBC_V_2_32 is not set
@@ -456,15 +462,18 @@ CT_GLIBC_V_2_34=y
 # CT_GLIBC_V_2_23 is not set
 # CT_GLIBC_V_2_19 is not set
 # CT_GLIBC_V_2_17 is not set
-# CT_GLIBC_V_2_12_1 is not set
 CT_GLIBC_VERSION="2.34"
 CT_GLIBC_MIRRORS="$(CT_Mirrors GNU glibc)"
 CT_GLIBC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GLIBC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_GLIBC_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
 CT_GLIBC_SIGNATURE_FORMAT="packed/.sig"
+CT_GLIBC_2_34_or_later=y
+CT_GLIBC_2_34_or_older=y
 CT_GLIBC_later_than_2_32=y
 CT_GLIBC_2_32_or_later=y
+CT_GLIBC_later_than_2_31=y
+CT_GLIBC_2_31_or_later=y
 CT_GLIBC_later_than_2_30=y
 CT_GLIBC_2_30_or_later=y
 CT_GLIBC_later_than_2_29=y
@@ -491,6 +500,7 @@ CT_GLIBC_DEP_KERNEL_HEADERS_VERSION=y
 CT_GLIBC_DEP_BINUTILS=y
 CT_GLIBC_DEP_GCC=y
 CT_GLIBC_DEP_PYTHON=y
+CT_THREADS="nptl"
 CT_GLIBC_BUILD_SSP=y
 CT_GLIBC_HAS_LIBIDN_ADDON=y
 # CT_GLIBC_USE_LIBIDN_ADDON is not set
@@ -506,7 +516,7 @@ CT_GLIBC_FORCE_UNWIND=y
 # CT_GLIBC_KERNEL_VERSION_NONE is not set
 CT_GLIBC_KERNEL_VERSION_AS_HEADERS=y
 # CT_GLIBC_KERNEL_VERSION_CHOSEN is not set
-CT_GLIBC_MIN_KERNEL="5.15.2"
+CT_GLIBC_MIN_KERNEL="5.15.37"
 CT_GLIBC_SSP_DEFAULT=y
 # CT_GLIBC_SSP_NO is not set
 # CT_GLIBC_SSP_YES is not set
@@ -514,7 +524,7 @@ CT_GLIBC_SSP_DEFAULT=y
 # CT_GLIBC_SSP_STRONG is not set
 CT_GLIBC_ENABLE_WERROR=y
 # CT_GLIBC_ENABLE_COMMON_FLAG is not set
-CT_ALL_LIBC_CHOICES="AVR_LIBC BIONIC GLIBC MINGW_W64 MOXIEBOX MUSL NEWLIB NONE UCLIBC"
+CT_ALL_LIBC_CHOICES="AVR_LIBC GLIBC MINGW_W64 MOXIEBOX MUSL NEWLIB NONE UCLIBC_NG"
 CT_LIBC_SUPPORT_THREADS_ANY=y
 CT_LIBC_SUPPORT_THREADS_NATIVE=y
 
@@ -529,7 +539,7 @@ CT_LIBC_XLDD=y
 #
 # C compiler
 #
-CT_CC_CORE_PASS_1_NEEDED=y
+CT_CC_CORE_NEEDED=y
 CT_CC_SUPPORT_CXX=y
 CT_CC_SUPPORT_FORTRAN=y
 CT_CC_SUPPORT_ADA=y
@@ -548,7 +558,6 @@ CT_CC_GCC_PKG_KSYM="GCC"
 CT_GCC_DIR_NAME="gcc"
 CT_GCC_USE_GNU=y
 # CT_GCC_USE_LINARO is not set
-# CT_GCC_USE_ORACLE is not set
 CT_GCC_USE="GCC"
 CT_GCC_PKG_NAME="gcc"
 CT_GCC_SRC_RELEASE=y
@@ -561,18 +570,21 @@ CT_GCC_PATCH_GLOBAL=y
 # CT_GCC_PATCH_LOCAL_BUNDLED is not set
 # CT_GCC_PATCH_NONE is not set
 CT_GCC_PATCH_ORDER="global"
+# CT_GCC_V_12 is not set
 CT_GCC_V_11=y
 # CT_GCC_V_10 is not set
 # CT_GCC_V_9 is not set
 # CT_GCC_V_8 is not set
 # CT_GCC_V_7 is not set
 # CT_GCC_V_6 is not set
-CT_GCC_VERSION="11.2.0"
+CT_GCC_VERSION="11.3.0"
 CT_GCC_MIRRORS="$(CT_Mirrors GNU gcc/gcc-${CT_GCC_VERSION}) $(CT_Mirrors sourceware gcc/releases/gcc-${CT_GCC_VERSION})"
 CT_GCC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GCC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_GCC_ARCHIVE_FORMATS=".tar.xz .tar.gz"
 CT_GCC_SIGNATURE_FORMAT=""
+CT_GCC_12_or_older=y
+CT_GCC_older_than_12=y
 CT_GCC_later_than_11=y
 CT_GCC_11_or_later=y
 CT_GCC_later_than_10=y
@@ -592,8 +604,6 @@ CT_GCC_REQUIRE_5_or_later=y
 CT_GCC_later_than_4_9=y
 CT_GCC_4_9_or_later=y
 CT_GCC_REQUIRE_4_9_or_later=y
-CT_GCC_later_than_4_8=y
-CT_GCC_4_8_or_later=y
 CT_CC_GCC_ENABLE_PLUGINS=y
 CT_CC_GCC_HAS_LIBMPX=y
 CT_CC_GCC_ENABLE_CXX_FLAGS=""
@@ -646,7 +656,7 @@ CT_ALL_CC_CHOICES="GCC"
 #
 CT_CC_LANG_CXX=y
 # CT_CC_LANG_FORTRAN is not set
-# CT_CC_LANG_ADA is not set
+CT_CC_LANG_ADA=y
 # CT_CC_LANG_OBJC is not set
 # CT_CC_LANG_OBJCXX is not set
 # CT_CC_LANG_GOLANG is not set
@@ -671,28 +681,25 @@ CT_GDB_PATCH_GLOBAL=y
 # CT_GDB_PATCH_LOCAL_BUNDLED is not set
 # CT_GDB_PATCH_NONE is not set
 CT_GDB_PATCH_ORDER="global"
-CT_GDB_V_11_1=y
-# CT_GDB_V_10_2 is not set
-# CT_GDB_V_9_2 is not set
+CT_GDB_V_12=y
+# CT_GDB_V_11 is not set
+# CT_GDB_V_10 is not set
+# CT_GDB_V_9 is not set
 # CT_GDB_V_8_3 is not set
-CT_GDB_VERSION="11.1"
+CT_GDB_VERSION="12.1"
 CT_GDB_MIRRORS="$(CT_Mirrors GNU gdb) $(CT_Mirrors sourceware gdb/releases)"
 CT_GDB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GDB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_GDB_ARCHIVE_FORMATS=".tar.xz .tar.gz"
 CT_GDB_SIGNATURE_FORMAT=""
-CT_GDB_11_1_or_later=y
-CT_GDB_11_1_or_older=y
-CT_GDB_later_than_10_2=y
-CT_GDB_10_2_or_later=y
+CT_GDB_later_than_12=y
+CT_GDB_12_or_later=y
+CT_GDB_later_than_11=y
+CT_GDB_11_or_later=y
+CT_GDB_later_than_10=y
+CT_GDB_10_or_later=y
 CT_GDB_later_than_8_3=y
 CT_GDB_8_3_or_later=y
-CT_GDB_later_than_8_0=y
-CT_GDB_8_0_or_later=y
-CT_GDB_later_than_7_12=y
-CT_GDB_7_12_or_later=y
-CT_GDB_later_than_7_11=y
-CT_GDB_7_11_or_later=y
 CT_GDB_CROSS=y
 # CT_GDB_CROSS_STATIC is not set
 # CT_GDB_CROSS_SIM is not set
@@ -758,6 +765,21 @@ CT_GETTEXT_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GETTEXT_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_GETTEXT_ARCHIVE_FORMATS=".tar.xz .tar.gz"
 CT_GETTEXT_SIGNATURE_FORMAT="packed/.sig"
+CT_GETTEXT_0_21_or_later=y
+CT_GETTEXT_0_21_or_older=y
+CT_GETTEXT_INCOMPATIBLE_WITH_UCLIBC_NG=y
+
+#
+# This version of gettext is not compatible with uClibc-NG. Select
+#
+
+#
+# a different version if uClibc-NG is used on the target or (in a
+#
+
+#
+# Canadian cross build) on the host.
+#
 CT_COMP_LIBS_GMP=y
 CT_COMP_LIBS_GMP_PKG_KSYM="GMP"
 CT_GMP_DIR_NAME="gmp"
@@ -780,11 +802,6 @@ CT_GMP_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GMP_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_GMP_ARCHIVE_FORMATS=".tar.xz .tar.lz .tar.bz2"
 CT_GMP_SIGNATURE_FORMAT="packed/.sig"
-CT_GMP_later_than_5_1_0=y
-CT_GMP_5_1_0_or_later=y
-CT_GMP_later_than_5_0_0=y
-CT_GMP_5_0_0_or_later=y
-CT_GMP_REQUIRE_5_0_0_or_later=y
 CT_COMP_LIBS_ISL=y
 CT_COMP_LIBS_ISL_PKG_KSYM="ISL"
 CT_ISL_DIR_NAME="isl"
@@ -800,6 +817,7 @@ CT_ISL_PATCH_GLOBAL=y
 # CT_ISL_PATCH_NONE is not set
 CT_ISL_PATCH_ORDER="global"
 CT_ISL_V_0_24=y
+# CT_ISL_V_0_23 is not set
 # CT_ISL_V_0_22 is not set
 # CT_ISL_V_0_21 is not set
 # CT_ISL_V_0_20 is not set
@@ -818,15 +836,6 @@ CT_ISL_later_than_0_18=y
 CT_ISL_0_18_or_later=y
 CT_ISL_later_than_0_15=y
 CT_ISL_0_15_or_later=y
-CT_ISL_REQUIRE_0_15_or_later=y
-CT_ISL_later_than_0_14=y
-CT_ISL_0_14_or_later=y
-CT_ISL_REQUIRE_0_14_or_later=y
-CT_ISL_later_than_0_13=y
-CT_ISL_0_13_or_later=y
-CT_ISL_later_than_0_12=y
-CT_ISL_0_12_or_later=y
-CT_ISL_REQUIRE_0_12_or_later=y
 # CT_COMP_LIBS_LIBELF is not set
 CT_COMP_LIBS_LIBICONV=y
 CT_COMP_LIBS_LIBICONV_PKG_KSYM="LIBICONV"
@@ -867,7 +876,7 @@ CT_MPC_PATCH_ORDER="global"
 CT_MPC_V_1_2=y
 # CT_MPC_V_1_1 is not set
 # CT_MPC_V_1_0 is not set
-CT_MPC_VERSION="1.2.0"
+CT_MPC_VERSION="1.2.1"
 CT_MPC_MIRRORS="http://www.multiprecision.org/downloads $(CT_Mirrors GNU mpc)"
 CT_MPC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_MPC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -900,9 +909,6 @@ CT_MPFR_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz .zip"
 CT_MPFR_SIGNATURE_FORMAT="packed/.asc"
 CT_MPFR_later_than_4_0_0=y
 CT_MPFR_4_0_0_or_later=y
-CT_MPFR_later_than_3_0_0=y
-CT_MPFR_3_0_0_or_later=y
-CT_MPFR_REQUIRE_3_0_0_or_later=y
 CT_COMP_LIBS_NCURSES=y
 CT_COMP_LIBS_NCURSES_PKG_KSYM="NCURSES"
 CT_NCURSES_DIR_NAME="ncurses"
@@ -947,8 +953,8 @@ CT_ZLIB_PATCH_GLOBAL=y
 # CT_ZLIB_PATCH_LOCAL_BUNDLED is not set
 # CT_ZLIB_PATCH_NONE is not set
 CT_ZLIB_PATCH_ORDER="global"
-CT_ZLIB_V_1_2_11=y
-CT_ZLIB_VERSION="1.2.11"
+CT_ZLIB_V_1_2_12=y
+CT_ZLIB_VERSION="1.2.12"
 CT_ZLIB_MIRRORS="http://downloads.sourceforge.net/project/libpng/zlib/${CT_ZLIB_VERSION} https://www.zlib.net/"
 CT_ZLIB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ZLIB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"


### PR DESCRIPTION
The config was not correctly enabling GNAT/Ada.

https://github.com/compiler-explorer/compiler-explorer/issues/3701
Signed-off-by: Marc Poulhiès <dkm@kataplop.net>