### PR TITLE
Change SH compilers

### DIFF
--- a/build/latest/sh-12.2.0.config
+++ b/build/latest/sh-12.2.0.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# crosstool-NG 1.25.0.77_3020aca_dirty Configuration
+# crosstool-NG 1.25.0.85_61c4cca_dirty Configuration
 #
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_cxx11=y
@@ -29,7 +29,7 @@ CT_CONFIGURE_has_sha1sum=y
 CT_CONFIGURE_has_sha256sum=y
 CT_CONFIGURE_has_sha512sum=y
 CT_CONFIGURE_has_install_with_strip_program=y
-CT_VERSION="1.25.0.77_3020aca_dirty"
+CT_VERSION="1.25.0.85_61c4cca_dirty"
 CT_VCHECK=""
 CT_CONFIG_VERSION_ENV="4"
 CT_CONFIG_VERSION_CURRENT="4"
@@ -44,8 +44,7 @@ CT_MODULES=y
 # crosstool-NG behavior
 #
 # CT_OBSOLETE is not set
-CT_EXPERIMENTAL=y
-# CT_ALLOW_BUILD_AS_ROOT is not set
+# CT_EXPERIMENTAL is not set
 # CT_DEBUG_CT is not set
 
 #
@@ -92,10 +91,7 @@ CT_VERIFY_DOWNLOAD_DIGEST_ALG="sha512"
 CT_OVERRIDE_CONFIG_GUESS_SUB=y
 # CT_ONLY_EXTRACT is not set
 CT_PATCH_BUNDLED=y
-# CT_PATCH_LOCAL is not set
 # CT_PATCH_BUNDLED_LOCAL is not set
-# CT_PATCH_LOCAL_BUNDLED is not set
-# CT_PATCH_NONE is not set
 CT_PATCH_ORDER="bundled"
 
 #
@@ -126,7 +122,7 @@ CT_LOG_EXTRA=y
 # CT_LOG_DEBUG is not set
 CT_LOG_LEVEL_MAX="EXTRA"
 # CT_LOG_SEE_TOOLS_WARN is not set
-CT_LOG_PROGRESS_BAR=n
+# CT_LOG_PROGRESS_BAR is not set
 CT_LOG_TO_FILE=y
 CT_LOG_FILE_COMPRESS=y
 # end of Paths and misc options
@@ -138,17 +134,11 @@ CT_LOG_FILE_COMPRESS=y
 # CT_ARCH_ARC is not set
 # CT_ARCH_ARM is not set
 # CT_ARCH_AVR is not set
-# CT_ARCH_C6X is not set
-# CT_ARCH_LOONGARCH is not set
 # CT_ARCH_M68K is not set
-# CT_ARCH_MICROBLAZE is not set
 # CT_ARCH_MIPS is not set
-# CT_ARCH_MOXIE is not set
-# CT_ARCH_MSP430 is not set
 # CT_ARCH_NIOS2 is not set
 # CT_ARCH_POWERPC is not set
 # CT_ARCH_PRU is not set
-# CT_ARCH_RISCV is not set
 # CT_ARCH_S390 is not set
 CT_ARCH_SH=y
 # CT_ARCH_SPARC is not set
@@ -156,7 +146,7 @@ CT_ARCH_SH=y
 # CT_ARCH_XTENSA is not set
 CT_ARCH="sh"
 CT_ARCH_CHOICE_KSYM="SH"
-CT_ARCH_CPU="sh4"
+CT_ARCH_CPU=""
 CT_ARCH_SH_SHOW=y
 
 #
@@ -182,7 +172,6 @@ CT_ARCH_SUFFIX=""
 #
 CT_ARCH_REQUIRES_MULTILIB=y
 CT_MULTILIB=y
-# CT_DEMULTILIB is not set
 CT_ARCH_SUPPORTS_BOTH_MMU=y
 CT_ARCH_DEFAULT_HAS_MMU=y
 CT_ARCH_USE_MMU=y
@@ -216,10 +205,6 @@ CT_TARGET_LDFLAGS=""
 #
 # General toolchain options
 #
-CT_FORCE_SYSROOT=y
-CT_USE_SYSROOT=y
-CT_SYSROOT_NAME="sysroot"
-CT_SYSROOT_DIR_PREFIX=""
 CT_WANTS_STATIC_LINK=y
 CT_WANTS_STATIC_LINK_CXX=y
 # CT_STATIC_TOOLCHAIN is not set
@@ -230,16 +215,14 @@ CT_TOOLCHAIN_BUGURL=""
 #
 # Tuple completion and aliasing
 #
-CT_TARGET_VENDOR="multilib"
+CT_TARGET_VENDOR="unknown"
 CT_TARGET_ALIAS_SED_EXPR=""
 CT_TARGET_ALIAS=""
 
 #
 # Toolchain type
 #
-# CT_NATIVE is not set
 CT_CROSS=y
-# CT_CROSS_NATIVE is not set
 # CT_CANADIAN is not set
 CT_TOOLCHAIN_TYPE="cross"
 
@@ -259,102 +242,22 @@ CT_BUILD_SUFFIX=""
 #
 # Operating System
 #
-CT_KERNEL_SUPPORTS_SHARED_LIBS=y
-# CT_KERNEL_BARE_METAL is not set
-CT_KERNEL_LINUX=y
-CT_KERNEL="linux"
-CT_KERNEL_CHOICE_KSYM="LINUX"
-CT_KERNEL_LINUX_SHOW=y
+CT_BARE_METAL=y
+CT_KERNEL_BARE_METAL=y
+# CT_KERNEL_LINUX is not set
+CT_KERNEL="bare-metal"
+CT_KERNEL_CHOICE_KSYM="BARE_METAL"
+CT_KERNEL_BARE_METAL_SHOW=y
 
 #
-# Options for linux
+# Options for bare-metal
 #
-CT_KERNEL_LINUX_PKG_KSYM="LINUX"
-CT_LINUX_DIR_NAME="linux"
-CT_LINUX_USE_WWW_KERNEL_ORG=y
-# CT_LINUX_USE_ORACLE is not set
-CT_LINUX_USE="LINUX"
-CT_LINUX_PKG_NAME="linux"
-CT_LINUX_SRC_RELEASE=y
-# CT_LINUX_SRC_DEVEL is not set
-# CT_LINUX_SRC_CUSTOM is not set
-CT_LINUX_PATCH_GLOBAL=y
-# CT_LINUX_PATCH_BUNDLED is not set
-# CT_LINUX_PATCH_LOCAL is not set
-# CT_LINUX_PATCH_BUNDLED_LOCAL is not set
-# CT_LINUX_PATCH_LOCAL_BUNDLED is not set
-# CT_LINUX_PATCH_NONE is not set
-CT_LINUX_PATCH_ORDER="global"
-CT_LINUX_V_5_19=y
-# CT_LINUX_V_5_18 is not set
-# CT_LINUX_V_5_17 is not set
-# CT_LINUX_V_5_16 is not set
-# CT_LINUX_V_5_15 is not set
-# CT_LINUX_V_5_14 is not set
-# CT_LINUX_V_5_13 is not set
-# CT_LINUX_V_5_12 is not set
-# CT_LINUX_V_5_11 is not set
-# CT_LINUX_V_5_10 is not set
-# CT_LINUX_V_5_9 is not set
-# CT_LINUX_V_5_8 is not set
-# CT_LINUX_V_5_7 is not set
-# CT_LINUX_V_5_4 is not set
-# CT_LINUX_V_5_3 is not set
-# CT_LINUX_V_5_2 is not set
-# CT_LINUX_V_5_1 is not set
-# CT_LINUX_V_5_0 is not set
-# CT_LINUX_V_4_20 is not set
-# CT_LINUX_V_4_19 is not set
-# CT_LINUX_V_4_18 is not set
-# CT_LINUX_V_4_17 is not set
-# CT_LINUX_V_4_16 is not set
-# CT_LINUX_V_4_15 is not set
-# CT_LINUX_V_4_14 is not set
-# CT_LINUX_V_4_13 is not set
-# CT_LINUX_V_4_12 is not set
-# CT_LINUX_V_4_11 is not set
-# CT_LINUX_V_4_10 is not set
-# CT_LINUX_V_4_9 is not set
-# CT_LINUX_V_4_4 is not set
-# CT_LINUX_V_4_1 is not set
-# CT_LINUX_V_3_16 is not set
-# CT_LINUX_V_3_13 is not set
-# CT_LINUX_V_3_12 is not set
-# CT_LINUX_V_3_10 is not set
-# CT_LINUX_V_3_4 is not set
-# CT_LINUX_V_3_2 is not set
-CT_LINUX_VERSION="5.19.2"
-CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
-CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
-CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
-CT_LINUX_ARCHIVE_FORMATS=".tar.xz .tar.gz"
-CT_LINUX_SIGNATURE_FORMAT="unpacked/.sign"
-CT_LINUX_later_than_5_19=y
-CT_LINUX_5_19_or_later=y
-CT_LINUX_later_than_5_12=y
-CT_LINUX_5_12_or_later=y
-CT_LINUX_later_than_5_5=y
-CT_LINUX_5_5_or_later=y
-CT_LINUX_later_than_5_3=y
-CT_LINUX_5_3_or_later=y
-CT_LINUX_later_than_4_8=y
-CT_LINUX_4_8_or_later=y
-CT_LINUX_later_than_3_7=y
-CT_LINUX_3_7_or_later=y
-CT_LINUX_later_than_3_2=y
-CT_LINUX_3_2_or_later=y
-CT_LINUX_REQUIRE_3_2_or_later=y
-CT_KERNEL_DEP_RSYNC=y
-CT_KERNEL_LINUX_VERBOSITY_0=y
-# CT_KERNEL_LINUX_VERBOSITY_1 is not set
-# CT_KERNEL_LINUX_VERBOSITY_2 is not set
-CT_KERNEL_LINUX_VERBOSE_LEVEL=0
+CT_KERNEL_BARE_METAL_PKG_KSYM=""
 CT_ALL_KERNEL_CHOICES="BARE_METAL LINUX WINDOWS"
 
 #
 # Common kernel options
 #
-CT_SHARED_LIBS=y
 # end of Operating System
 
 #
@@ -372,19 +275,11 @@ CT_BINUTILS_BINUTILS_SHOW=y
 CT_BINUTILS_BINUTILS_PKG_KSYM="BINUTILS"
 CT_BINUTILS_DIR_NAME="binutils"
 CT_BINUTILS_USE_GNU=y
-# CT_BINUTILS_USE_LINARO is not set
 # CT_BINUTILS_USE_ORACLE is not set
 CT_BINUTILS_USE="BINUTILS"
 CT_BINUTILS_PKG_NAME="binutils"
 CT_BINUTILS_SRC_RELEASE=y
 # CT_BINUTILS_SRC_DEVEL is not set
-# CT_BINUTILS_SRC_CUSTOM is not set
-CT_BINUTILS_PATCH_GLOBAL=y
-# CT_BINUTILS_PATCH_BUNDLED is not set
-# CT_BINUTILS_PATCH_LOCAL is not set
-# CT_BINUTILS_PATCH_BUNDLED_LOCAL is not set
-# CT_BINUTILS_PATCH_LOCAL_BUNDLED is not set
-# CT_BINUTILS_PATCH_NONE is not set
 CT_BINUTILS_PATCH_ORDER="global"
 CT_BINUTILS_V_2_39=y
 # CT_BINUTILS_V_2_38 is not set
@@ -418,7 +313,6 @@ CT_BINUTILS_2_26_or_later=y
 #
 # GNU binutils
 #
-CT_BINUTILS_FORCE_LD_BFD_DEFAULT=y
 CT_BINUTILS_LINKER_LD=y
 CT_BINUTILS_LINKERS_LIST="ld"
 CT_BINUTILS_LINKER_DEFAULT="bfd"
@@ -426,131 +320,71 @@ CT_BINUTILS_PLUGINS=y
 CT_BINUTILS_RELRO=m
 CT_BINUTILS_DETERMINISTIC_ARCHIVES=y
 CT_BINUTILS_EXTRA_CONFIG_ARRAY=""
-# CT_BINUTILS_FOR_TARGET is not set
 CT_ALL_BINUTILS_CHOICES="BINUTILS"
 # end of Binary utilities
 
 #
 # C-library
 #
-CT_LIBC_GLIBC=y
-# CT_LIBC_MUSL is not set
-# CT_LIBC_UCLIBC_NG is not set
-CT_LIBC="glibc"
-CT_LIBC_CHOICE_KSYM="GLIBC"
-CT_LIBC_GLIBC_SHOW=y
+CT_LIBC_NEWLIB=y
+# CT_LIBC_NONE is not set
+CT_LIBC="newlib"
+CT_LIBC_CHOICE_KSYM="NEWLIB"
+CT_THREADS="none"
+CT_LIBC_NEWLIB_SHOW=y
 
 #
-# Options for glibc
+# Options for newlib
 #
-CT_LIBC_GLIBC_PKG_KSYM="GLIBC"
-CT_GLIBC_DIR_NAME="glibc"
-CT_GLIBC_USE_GNU=y
-# CT_GLIBC_USE_ORACLE is not set
-CT_GLIBC_USE="GLIBC"
-CT_GLIBC_PKG_NAME="glibc"
-CT_GLIBC_SRC_RELEASE=y
-# CT_GLIBC_SRC_DEVEL is not set
-# CT_GLIBC_SRC_CUSTOM is not set
-CT_GLIBC_PATCH_GLOBAL=y
-# CT_GLIBC_PATCH_BUNDLED is not set
-# CT_GLIBC_PATCH_LOCAL is not set
-# CT_GLIBC_PATCH_BUNDLED_LOCAL is not set
-# CT_GLIBC_PATCH_LOCAL_BUNDLED is not set
-# CT_GLIBC_PATCH_NONE is not set
-CT_GLIBC_PATCH_ORDER="global"
-CT_GLIBC_V_2_36=y
-# CT_GLIBC_V_2_35 is not set
-# CT_GLIBC_V_2_34 is not set
-# CT_GLIBC_V_2_33 is not set
-# CT_GLIBC_V_2_32 is not set
-# CT_GLIBC_V_2_31 is not set
-# CT_GLIBC_V_2_30 is not set
-# CT_GLIBC_V_2_29 is not set
-# CT_GLIBC_V_2_28 is not set
-# CT_GLIBC_V_2_27 is not set
-# CT_GLIBC_V_2_26 is not set
-# CT_GLIBC_V_2_25 is not set
-# CT_GLIBC_V_2_24 is not set
-# CT_GLIBC_V_2_23 is not set
-# CT_GLIBC_V_2_19 is not set
-# CT_GLIBC_V_2_17 is not set
-CT_GLIBC_VERSION="2.36"
-CT_GLIBC_MIRRORS="$(CT_Mirrors GNU glibc)"
-CT_GLIBC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
-CT_GLIBC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
-CT_GLIBC_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
-CT_GLIBC_SIGNATURE_FORMAT="packed/.sig"
-CT_GLIBC_2_36_or_later=y
-CT_GLIBC_2_36_or_older=y
-CT_GLIBC_later_than_2_34=y
-CT_GLIBC_2_34_or_later=y
-CT_GLIBC_later_than_2_32=y
-CT_GLIBC_2_32_or_later=y
-CT_GLIBC_later_than_2_31=y
-CT_GLIBC_2_31_or_later=y
-CT_GLIBC_later_than_2_30=y
-CT_GLIBC_2_30_or_later=y
-CT_GLIBC_later_than_2_29=y
-CT_GLIBC_2_29_or_later=y
-CT_GLIBC_later_than_2_28=y
-CT_GLIBC_2_28_or_later=y
-CT_GLIBC_later_than_2_27=y
-CT_GLIBC_2_27_or_later=y
-CT_GLIBC_later_than_2_26=y
-CT_GLIBC_2_26_or_later=y
-CT_GLIBC_later_than_2_25=y
-CT_GLIBC_2_25_or_later=y
-CT_GLIBC_later_than_2_24=y
-CT_GLIBC_2_24_or_later=y
-CT_GLIBC_later_than_2_23=y
-CT_GLIBC_2_23_or_later=y
-CT_GLIBC_later_than_2_20=y
-CT_GLIBC_2_20_or_later=y
-CT_GLIBC_later_than_2_17=y
-CT_GLIBC_2_17_or_later=y
-CT_GLIBC_later_than_2_14=y
-CT_GLIBC_2_14_or_later=y
-CT_GLIBC_DEP_KERNEL_HEADERS_VERSION=y
-CT_GLIBC_DEP_BINUTILS=y
-CT_GLIBC_DEP_GCC=y
-CT_GLIBC_DEP_PYTHON=y
-CT_THREADS="nptl"
-CT_GLIBC_BUILD_SSP=y
-CT_GLIBC_HAS_LIBIDN_ADDON=y
-# CT_GLIBC_USE_LIBIDN_ADDON is not set
-CT_GLIBC_NO_SPARC_V8=y
-CT_GLIBC_EXTRA_CONFIG_ARRAY=""
-CT_GLIBC_CONFIGPARMS="no-z-defs=yes"
-CT_GLIBC_ENABLE_DEBUG=y
-CT_GLIBC_EXTRA_CFLAGS=""
-# CT_GLIBC_ENABLE_FORTIFIED_BUILD is not set
-# CT_GLIBC_DISABLE_VERSIONING is not set
-CT_GLIBC_OLDEST_ABI=""
-CT_GLIBC_FORCE_UNWIND=y
-# CT_GLIBC_LOCALES is not set
-# CT_GLIBC_KERNEL_VERSION_NONE is not set
-CT_GLIBC_KERNEL_VERSION_AS_HEADERS=y
-# CT_GLIBC_KERNEL_VERSION_CHOSEN is not set
-CT_GLIBC_MIN_KERNEL="5.19.2"
-CT_GLIBC_SSP_DEFAULT=y
-# CT_GLIBC_SSP_NO is not set
-# CT_GLIBC_SSP_YES is not set
-# CT_GLIBC_SSP_ALL is not set
-# CT_GLIBC_SSP_STRONG is not set
-CT_GLIBC_ENABLE_WERROR=y
-# CT_GLIBC_ENABLE_COMMON_FLAG is not set
+CT_LIBC_NEWLIB_PKG_KSYM="NEWLIB"
+CT_NEWLIB_DIR_NAME="newlib"
+CT_NEWLIB_PKG_NAME="newlib"
+CT_NEWLIB_SRC_RELEASE=y
+# CT_NEWLIB_SRC_DEVEL is not set
+CT_NEWLIB_PATCH_ORDER="global"
+CT_NEWLIB_V_4_1=y
+# CT_NEWLIB_V_3_3 is not set
+# CT_NEWLIB_V_3_2 is not set
+# CT_NEWLIB_V_3_1 is not set
+# CT_NEWLIB_V_3_0 is not set
+# CT_NEWLIB_V_2_5 is not set
+CT_NEWLIB_VERSION="4.1.0"
+CT_NEWLIB_MIRRORS="ftp://sourceware.org/pub/newlib"
+CT_NEWLIB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_NEWLIB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_NEWLIB_ARCHIVE_FORMATS=".tar.gz"
+CT_NEWLIB_SIGNATURE_FORMAT=""
+CT_LIBC_NEWLIB_TARGET_CFLAGS=""
+# CT_LIBC_NEWLIB_IO_C99FMT is not set
+# CT_LIBC_NEWLIB_IO_LL is not set
+# CT_LIBC_NEWLIB_IO_FLOAT is not set
+# CT_LIBC_NEWLIB_IO_POS_ARGS is not set
+CT_LIBC_NEWLIB_FVWRITE_IN_STREAMIO=y
+CT_LIBC_NEWLIB_UNBUF_STREAM_OPT=y
+CT_LIBC_NEWLIB_FSEEK_OPTIMIZATION=y
+# CT_LIBC_NEWLIB_DISABLE_SUPPLIED_SYSCALLS is not set
+# CT_LIBC_NEWLIB_REGISTER_FINI is not set
+CT_LIBC_NEWLIB_ATEXIT_DYNAMIC_ALLOC=y
+# CT_LIBC_NEWLIB_GLOBAL_ATEXIT is not set
+# CT_LIBC_NEWLIB_LITE_EXIT is not set
+# CT_LIBC_NEWLIB_REENT_SMALL is not set
+CT_LIBC_NEWLIB_MULTITHREAD=y
+# CT_LIBC_NEWLIB_RETARGETABLE_LOCKING is not set
+# CT_LIBC_NEWLIB_EXTRA_SECTIONS is not set
+CT_LIBC_NEWLIB_WIDE_ORIENT=y
+CT_LIBC_NEWLIB_ENABLE_TARGET_OPTSPACE=y
+# CT_LIBC_NEWLIB_LTO is not set
+# CT_LIBC_NEWLIB_NANO_MALLOC is not set
+# CT_LIBC_NEWLIB_NANO_FORMATTED_IO is not set
+CT_LIBC_NEWLIB_EXTRA_CONFIG_ARRAY=""
 CT_ALL_LIBC_CHOICES="AVR_LIBC GLIBC MINGW_W64 MOXIEBOX MUSL NEWLIB NONE UCLIBC_NG"
-CT_LIBC_SUPPORT_THREADS_ANY=y
-CT_LIBC_SUPPORT_THREADS_NATIVE=y
+CT_LIBC_SUPPORT_THREADS_NONE=y
+CT_LIBC_PROVIDES_CXA_ATEXIT=y
 
 #
 # Common C library options
 #
-CT_THREADS_NATIVE=y
-CT_CREATE_LDSO_CONF=y
-CT_LDSO_CONF_EXTRA_DIRS_ARRAY=""
-CT_LIBC_XLDD=y
+CT_THREADS_NONE=y
 # end of C-library
 
 #
@@ -575,19 +409,11 @@ CT_CC_GCC_SHOW=y
 CT_CC_GCC_PKG_KSYM="GCC"
 CT_GCC_DIR_NAME="gcc"
 CT_GCC_USE_GNU=y
-# CT_GCC_USE_LINARO is not set
 # CT_GCC_USE_ORACLE is not set
 CT_GCC_USE="GCC"
 CT_GCC_PKG_NAME="gcc"
 CT_GCC_SRC_RELEASE=y
 # CT_GCC_SRC_DEVEL is not set
-# CT_GCC_SRC_CUSTOM is not set
-CT_GCC_PATCH_GLOBAL=y
-# CT_GCC_PATCH_BUNDLED is not set
-# CT_GCC_PATCH_LOCAL is not set
-# CT_GCC_PATCH_BUNDLED_LOCAL is not set
-# CT_GCC_PATCH_LOCAL_BUNDLED is not set
-# CT_GCC_PATCH_NONE is not set
 CT_GCC_PATCH_ORDER="global"
 CT_GCC_V_12=y
 # CT_GCC_V_11 is not set
@@ -596,6 +422,8 @@ CT_GCC_V_12=y
 # CT_GCC_V_8 is not set
 # CT_GCC_V_7 is not set
 # CT_GCC_V_6 is not set
+# CT_GCC_V_5 is not set
+# CT_GCC_V_4_9 is not set
 CT_GCC_VERSION="12.2.0"
 CT_GCC_MIRRORS="$(CT_Mirrors GNU gcc/gcc-${CT_GCC_VERSION}) $(CT_Mirrors sourceware gcc/releases/gcc-${CT_GCC_VERSION})"
 CT_GCC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
@@ -616,19 +444,16 @@ CT_GCC_later_than_7=y
 CT_GCC_7_or_later=y
 CT_GCC_later_than_6=y
 CT_GCC_6_or_later=y
-CT_GCC_REQUIRE_6_or_later=y
 CT_GCC_later_than_5=y
 CT_GCC_5_or_later=y
-CT_GCC_REQUIRE_5_or_later=y
 CT_GCC_later_than_4_9=y
 CT_GCC_4_9_or_later=y
-CT_GCC_REQUIRE_4_9_or_later=y
 CT_CC_GCC_ENABLE_PLUGINS=y
 CT_CC_GCC_HAS_LIBMPX=y
 CT_CC_GCC_ENABLE_CXX_FLAGS=""
 CT_CC_GCC_CORE_EXTRA_CONFIG_ARRAY=""
 CT_CC_GCC_EXTRA_CONFIG_ARRAY=""
-CT_CC_GCC_MULTILIB_LIST="m4-nofpu,m4a,m3"
+CT_CC_GCC_MULTILIB_LIST="m2,m2e,m4,m4-single,m4-single-only,m2a,m2a-single"
 CT_CC_GCC_STATIC_LIBSTDCXX=y
 # CT_CC_GCC_SYSTEM_ZLIB is not set
 CT_CC_GCC_CONFIG_TLS=m
@@ -646,10 +471,9 @@ CT_CC_GCC_LTO_ZSTD=m
 CT_CC_GCC_ENABLE_DEFAULT_PIE=y
 CT_CC_GCC_ENABLE_TARGET_OPTSPACE=y
 # CT_CC_GCC_LIBMUDFLAP is not set
-# CT_CC_GCC_LIBGOMP is not set
 # CT_CC_GCC_LIBSSP is not set
 # CT_CC_GCC_LIBQUADMATH is not set
-CT_CC_GCC_LIBSTDCXX_VERBOSE=m
+# CT_CC_GCC_LIBSTDCXX_VERBOSE is not set
 
 #
 # Misc. obscure options.
@@ -657,7 +481,6 @@ CT_CC_GCC_LIBSTDCXX_VERBOSE=m
 CT_CC_CXA_ATEXIT=y
 CT_CC_GCC_TM_CLONE_REGISTRY=m
 # CT_CC_GCC_DISABLE_PCH is not set
-CT_CC_GCC_SJLJ_EXCEPTIONS=m
 CT_CC_GCC_LDBL_128=m
 # CT_CC_GCC_BUILD_ID is not set
 CT_CC_GCC_LNK_HASH_STYLE_DEFAULT=y
@@ -676,19 +499,12 @@ CT_ALL_CC_CHOICES="GCC"
 # Additional supported languages:
 #
 CT_CC_LANG_CXX=y
-CT_CC_LANG_FORTRAN=y
-# CT_CC_LANG_ADA is not set
-CT_CC_LANG_D=y
-CT_CC_LANG_OBJC=y
-# CT_CC_LANG_OBJCXX is not set
-# CT_CC_LANG_GOLANG is not set
-CT_CC_LANG_OTHERS=""
+# CT_CC_LANG_FORTRAN is not set
 # end of C compiler
 
 #
 # Debug facilities
 #
-# CT_DEBUG_DUMA is not set
 # CT_DEBUG_GDB is not set
 # CT_DEBUG_LTRACE is not set
 # CT_DEBUG_STRACE is not set
@@ -699,79 +515,28 @@ CT_ALL_DEBUG_CHOICES="DUMA GDB LTRACE STRACE"
 # Companion libraries
 #
 # CT_COMPLIBS_CHECK is not set
-# CT_COMP_LIBS_CLOOG is not set
-CT_COMP_LIBS_EXPAT=y
-CT_COMP_LIBS_EXPAT_PKG_KSYM="EXPAT"
-CT_EXPAT_DIR_NAME="expat"
-CT_EXPAT_PKG_NAME="expat"
-CT_EXPAT_SRC_RELEASE=y
-# CT_EXPAT_SRC_DEVEL is not set
-# CT_EXPAT_SRC_CUSTOM is not set
-CT_EXPAT_PATCH_GLOBAL=y
-# CT_EXPAT_PATCH_BUNDLED is not set
-# CT_EXPAT_PATCH_LOCAL is not set
-# CT_EXPAT_PATCH_BUNDLED_LOCAL is not set
-# CT_EXPAT_PATCH_LOCAL_BUNDLED is not set
-# CT_EXPAT_PATCH_NONE is not set
-CT_EXPAT_PATCH_ORDER="global"
-CT_EXPAT_V_2_4=y
-CT_EXPAT_VERSION="2.4.1"
-CT_EXPAT_MIRRORS="http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION} https://github.com/libexpat/libexpat/releases/download/R_${CT_EXPAT_VERSION//./_}"
-CT_EXPAT_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
-CT_EXPAT_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
-CT_EXPAT_ARCHIVE_FORMATS=".tar.xz .tar.lz .tar.bz2 .tar.gz"
-CT_EXPAT_SIGNATURE_FORMAT=""
-CT_COMP_LIBS_GETTEXT=y
-CT_COMP_LIBS_GETTEXT_PKG_KSYM="GETTEXT"
-CT_GETTEXT_DIR_NAME="gettext"
-CT_GETTEXT_PKG_NAME="gettext"
-CT_GETTEXT_SRC_RELEASE=y
-# CT_GETTEXT_SRC_DEVEL is not set
-# CT_GETTEXT_SRC_CUSTOM is not set
-CT_GETTEXT_PATCH_GLOBAL=y
-# CT_GETTEXT_PATCH_BUNDLED is not set
-# CT_GETTEXT_PATCH_LOCAL is not set
-# CT_GETTEXT_PATCH_BUNDLED_LOCAL is not set
-# CT_GETTEXT_PATCH_LOCAL_BUNDLED is not set
-# CT_GETTEXT_PATCH_NONE is not set
-CT_GETTEXT_PATCH_ORDER="global"
-CT_GETTEXT_V_0_21=y
-# CT_GETTEXT_V_0_20_1 is not set
-# CT_GETTEXT_V_0_19_8_1 is not set
-CT_GETTEXT_VERSION="0.21"
-CT_GETTEXT_MIRRORS="$(CT_Mirrors GNU gettext)"
-CT_GETTEXT_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
-CT_GETTEXT_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
-CT_GETTEXT_ARCHIVE_FORMATS=".tar.xz .tar.gz"
-CT_GETTEXT_SIGNATURE_FORMAT="packed/.sig"
-CT_GETTEXT_0_21_or_later=y
-CT_GETTEXT_0_21_or_older=y
-CT_GETTEXT_INCOMPATIBLE_WITH_UCLIBC_NG=y
-
-#
-# This version of gettext is not compatible with uClibc-NG. Select
-#
-
-#
-# a different version if uClibc-NG is used on the target or (in a
-#
-
-#
-# Canadian cross build) on the host.
-#
+CT_COMP_LIBS_CLOOG=y
+CT_COMP_LIBS_CLOOG_PKG_KSYM="CLOOG"
+CT_CLOOG_DIR_NAME="cloog"
+CT_CLOOG_PKG_NAME="cloog"
+CT_CLOOG_SRC_RELEASE=y
+# CT_CLOOG_SRC_DEVEL is not set
+CT_CLOOG_PATCH_ORDER="global"
+CT_CLOOG_V_0_18_4=y
+CT_CLOOG_VERSION="0.18.4"
+CT_CLOOG_MIRRORS="http://www.bastoul.net/cloog/pages/download"
+CT_CLOOG_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_CLOOG_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_CLOOG_ARCHIVE_FORMATS=".tar.gz"
+CT_CLOOG_SIGNATURE_FORMAT=""
+# CT_COMP_LIBS_EXPAT is not set
+# CT_COMP_LIBS_GETTEXT is not set
 CT_COMP_LIBS_GMP=y
 CT_COMP_LIBS_GMP_PKG_KSYM="GMP"
 CT_GMP_DIR_NAME="gmp"
 CT_GMP_PKG_NAME="gmp"
 CT_GMP_SRC_RELEASE=y
 # CT_GMP_SRC_DEVEL is not set
-# CT_GMP_SRC_CUSTOM is not set
-CT_GMP_PATCH_GLOBAL=y
-# CT_GMP_PATCH_BUNDLED is not set
-# CT_GMP_PATCH_LOCAL is not set
-# CT_GMP_PATCH_BUNDLED_LOCAL is not set
-# CT_GMP_PATCH_LOCAL_BUNDLED is not set
-# CT_GMP_PATCH_NONE is not set
 CT_GMP_PATCH_ORDER="global"
 CT_GMP_V_6_2=y
 # CT_GMP_V_6_1 is not set
@@ -787,15 +552,8 @@ CT_ISL_DIR_NAME="isl"
 CT_ISL_PKG_NAME="isl"
 CT_ISL_SRC_RELEASE=y
 # CT_ISL_SRC_DEVEL is not set
-# CT_ISL_SRC_CUSTOM is not set
-CT_ISL_PATCH_GLOBAL=y
-# CT_ISL_PATCH_BUNDLED is not set
-# CT_ISL_PATCH_LOCAL is not set
-# CT_ISL_PATCH_BUNDLED_LOCAL is not set
-# CT_ISL_PATCH_LOCAL_BUNDLED is not set
-# CT_ISL_PATCH_NONE is not set
 CT_ISL_PATCH_ORDER="global"
-CT_ISL_V_0_24=y
+# CT_ISL_V_0_24 is not set
 # CT_ISL_V_0_23 is not set
 # CT_ISL_V_0_22 is not set
 # CT_ISL_V_0_21 is not set
@@ -804,53 +562,25 @@ CT_ISL_V_0_24=y
 # CT_ISL_V_0_18 is not set
 # CT_ISL_V_0_17 is not set
 # CT_ISL_V_0_16 is not set
-# CT_ISL_V_0_15 is not set
-CT_ISL_VERSION="0.24"
+CT_ISL_V_0_15=y
+CT_ISL_VERSION="0.15"
 CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
 CT_ISL_SIGNATURE_FORMAT=""
-CT_ISL_later_than_0_18=y
-CT_ISL_0_18_or_later=y
-CT_ISL_later_than_0_15=y
+CT_ISL_0_18_or_older=y
+CT_ISL_older_than_0_18=y
 CT_ISL_0_15_or_later=y
+CT_ISL_0_15_or_older=y
 # CT_COMP_LIBS_LIBELF is not set
-CT_COMP_LIBS_LIBICONV=y
-CT_COMP_LIBS_LIBICONV_PKG_KSYM="LIBICONV"
-CT_LIBICONV_DIR_NAME="libiconv"
-CT_LIBICONV_PKG_NAME="libiconv"
-CT_LIBICONV_SRC_RELEASE=y
-# CT_LIBICONV_SRC_DEVEL is not set
-# CT_LIBICONV_SRC_CUSTOM is not set
-CT_LIBICONV_PATCH_GLOBAL=y
-# CT_LIBICONV_PATCH_BUNDLED is not set
-# CT_LIBICONV_PATCH_LOCAL is not set
-# CT_LIBICONV_PATCH_BUNDLED_LOCAL is not set
-# CT_LIBICONV_PATCH_LOCAL_BUNDLED is not set
-# CT_LIBICONV_PATCH_NONE is not set
-CT_LIBICONV_PATCH_ORDER="global"
-CT_LIBICONV_V_1_16=y
-# CT_LIBICONV_V_1_15 is not set
-CT_LIBICONV_VERSION="1.16"
-CT_LIBICONV_MIRRORS="$(CT_Mirrors GNU libiconv)"
-CT_LIBICONV_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
-CT_LIBICONV_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
-CT_LIBICONV_ARCHIVE_FORMATS=".tar.gz"
-CT_LIBICONV_SIGNATURE_FORMAT="packed/.sig"
+# CT_COMP_LIBS_LIBICONV is not set
 CT_COMP_LIBS_MPC=y
 CT_COMP_LIBS_MPC_PKG_KSYM="MPC"
 CT_MPC_DIR_NAME="mpc"
 CT_MPC_PKG_NAME="mpc"
 CT_MPC_SRC_RELEASE=y
 # CT_MPC_SRC_DEVEL is not set
-# CT_MPC_SRC_CUSTOM is not set
-CT_MPC_PATCH_GLOBAL=y
-# CT_MPC_PATCH_BUNDLED is not set
-# CT_MPC_PATCH_LOCAL is not set
-# CT_MPC_PATCH_BUNDLED_LOCAL is not set
-# CT_MPC_PATCH_LOCAL_BUNDLED is not set
-# CT_MPC_PATCH_NONE is not set
 CT_MPC_PATCH_ORDER="global"
 CT_MPC_V_1_2=y
 # CT_MPC_V_1_1 is not set
@@ -869,13 +599,6 @@ CT_MPFR_DIR_NAME="mpfr"
 CT_MPFR_PKG_NAME="mpfr"
 CT_MPFR_SRC_RELEASE=y
 # CT_MPFR_SRC_DEVEL is not set
-# CT_MPFR_SRC_CUSTOM is not set
-CT_MPFR_PATCH_GLOBAL=y
-# CT_MPFR_PATCH_BUNDLED is not set
-# CT_MPFR_PATCH_LOCAL is not set
-# CT_MPFR_PATCH_BUNDLED_LOCAL is not set
-# CT_MPFR_PATCH_LOCAL_BUNDLED is not set
-# CT_MPFR_PATCH_NONE is not set
 CT_MPFR_PATCH_ORDER="global"
 CT_MPFR_V_4_1=y
 # CT_MPFR_V_4_0 is not set
@@ -888,49 +611,14 @@ CT_MPFR_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz .zip"
 CT_MPFR_SIGNATURE_FORMAT="packed/.asc"
 CT_MPFR_later_than_4_0_0=y
 CT_MPFR_4_0_0_or_later=y
-CT_COMP_LIBS_NCURSES=y
-CT_COMP_LIBS_NCURSES_PKG_KSYM="NCURSES"
-CT_NCURSES_DIR_NAME="ncurses"
-CT_NCURSES_PKG_NAME="ncurses"
-CT_NCURSES_SRC_RELEASE=y
-# CT_NCURSES_SRC_DEVEL is not set
-# CT_NCURSES_SRC_CUSTOM is not set
-CT_NCURSES_PATCH_GLOBAL=y
-# CT_NCURSES_PATCH_BUNDLED is not set
-# CT_NCURSES_PATCH_LOCAL is not set
-# CT_NCURSES_PATCH_BUNDLED_LOCAL is not set
-# CT_NCURSES_PATCH_LOCAL_BUNDLED is not set
-# CT_NCURSES_PATCH_NONE is not set
-CT_NCURSES_PATCH_ORDER="global"
-CT_NCURSES_V_6_2=y
-# CT_NCURSES_V_6_1 is not set
-# CT_NCURSES_V_6_0 is not set
-CT_NCURSES_VERSION="6.2"
-CT_NCURSES_MIRRORS="https://invisible-mirror.net/archives/ncurses $(CT_Mirrors GNU ncurses)"
-CT_NCURSES_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
-CT_NCURSES_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
-CT_NCURSES_ARCHIVE_FORMATS=".tar.gz"
-CT_NCURSES_SIGNATURE_FORMAT="packed/.sig"
-CT_NCURSES_NEW_ABI=y
-CT_NCURSES_HOST_CONFIG_ARGS=""
-CT_NCURSES_HOST_DISABLE_DB=y
-CT_NCURSES_HOST_FALLBACKS="linux,xterm,xterm-color,xterm-256color,vt100"
-CT_NCURSES_TARGET_CONFIG_ARGS=""
-# CT_NCURSES_TARGET_DISABLE_DB is not set
-CT_NCURSES_TARGET_FALLBACKS=""
+# CT_COMP_LIBS_NCURSES is not set
+# CT_COMP_LIBS_NEWLIB_NANO is not set
 CT_COMP_LIBS_ZLIB=y
 CT_COMP_LIBS_ZLIB_PKG_KSYM="ZLIB"
 CT_ZLIB_DIR_NAME="zlib"
 CT_ZLIB_PKG_NAME="zlib"
 CT_ZLIB_SRC_RELEASE=y
 # CT_ZLIB_SRC_DEVEL is not set
-# CT_ZLIB_SRC_CUSTOM is not set
-CT_ZLIB_PATCH_GLOBAL=y
-# CT_ZLIB_PATCH_BUNDLED is not set
-# CT_ZLIB_PATCH_LOCAL is not set
-# CT_ZLIB_PATCH_BUNDLED_LOCAL is not set
-# CT_ZLIB_PATCH_LOCAL_BUNDLED is not set
-# CT_ZLIB_PATCH_NONE is not set
 CT_ZLIB_PATCH_ORDER="global"
 CT_ZLIB_V_1_2_12=y
 CT_ZLIB_VERSION="1.2.12"
@@ -940,21 +628,17 @@ CT_ZLIB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ZLIB_ARCHIVE_FORMATS=".tar.xz .tar.gz"
 CT_ZLIB_SIGNATURE_FORMAT="packed/.asc"
 CT_ALL_COMP_LIBS_CHOICES="CLOOG EXPAT GETTEXT GMP GNUPRUMCU ISL LIBELF LIBICONV MPC MPFR NCURSES NEWLIB_NANO PICOLIBC ZLIB"
-CT_LIBICONV_NEEDED=y
-CT_GETTEXT_NEEDED=y
+# CT_LIBICONV_NEEDED is not set
+# CT_GETTEXT_NEEDED is not set
 CT_GMP_NEEDED=y
 CT_MPFR_NEEDED=y
 CT_ISL_NEEDED=y
 CT_MPC_NEEDED=y
-CT_NCURSES_NEEDED=y
 CT_ZLIB_NEEDED=y
-CT_LIBICONV=y
-CT_GETTEXT=y
 CT_GMP=y
 CT_MPFR=y
 CT_ISL=y
 CT_MPC=y
-CT_NCURSES=y
 CT_ZLIB=y
 # end of Companion libraries
 
@@ -971,9 +655,3 @@ CT_ZLIB=y
 # CT_COMP_TOOLS_MAKE is not set
 CT_ALL_COMP_TOOLS_CHOICES="AUTOCONF AUTOMAKE BISON DTC LIBTOOL M4 MAKE"
 # end of Companion tools
-
-#
-# Test suite
-#
-# CT_TEST_SUITE_GCC is not set
-# end of Test suite

--- a/build/latest/sh-9.5.0.config
+++ b/build/latest/sh-9.5.0.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# crosstool-NG 1.25.0.77_3020aca_dirty Configuration
+# crosstool-NG 1.25.0.85_61c4cca_dirty Configuration
 #
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_cxx11=y
@@ -29,7 +29,7 @@ CT_CONFIGURE_has_sha1sum=y
 CT_CONFIGURE_has_sha256sum=y
 CT_CONFIGURE_has_sha512sum=y
 CT_CONFIGURE_has_install_with_strip_program=y
-CT_VERSION="1.25.0.77_3020aca_dirty"
+CT_VERSION="1.25.0.85_61c4cca_dirty"
 CT_VCHECK=""
 CT_CONFIG_VERSION_ENV="4"
 CT_CONFIG_VERSION_CURRENT="4"
@@ -44,8 +44,7 @@ CT_MODULES=y
 # crosstool-NG behavior
 #
 # CT_OBSOLETE is not set
-CT_EXPERIMENTAL=y
-# CT_ALLOW_BUILD_AS_ROOT is not set
+# CT_EXPERIMENTAL is not set
 # CT_DEBUG_CT is not set
 
 #
@@ -92,10 +91,7 @@ CT_VERIFY_DOWNLOAD_DIGEST_ALG="sha512"
 CT_OVERRIDE_CONFIG_GUESS_SUB=y
 # CT_ONLY_EXTRACT is not set
 CT_PATCH_BUNDLED=y
-# CT_PATCH_LOCAL is not set
 # CT_PATCH_BUNDLED_LOCAL is not set
-# CT_PATCH_LOCAL_BUNDLED is not set
-# CT_PATCH_NONE is not set
 CT_PATCH_ORDER="bundled"
 
 #
@@ -126,7 +122,7 @@ CT_LOG_EXTRA=y
 # CT_LOG_DEBUG is not set
 CT_LOG_LEVEL_MAX="EXTRA"
 # CT_LOG_SEE_TOOLS_WARN is not set
-CT_LOG_PROGRESS_BAR=n
+# CT_LOG_PROGRESS_BAR is not set
 CT_LOG_TO_FILE=y
 CT_LOG_FILE_COMPRESS=y
 # end of Paths and misc options
@@ -138,17 +134,11 @@ CT_LOG_FILE_COMPRESS=y
 # CT_ARCH_ARC is not set
 # CT_ARCH_ARM is not set
 # CT_ARCH_AVR is not set
-# CT_ARCH_C6X is not set
-# CT_ARCH_LOONGARCH is not set
 # CT_ARCH_M68K is not set
-# CT_ARCH_MICROBLAZE is not set
 # CT_ARCH_MIPS is not set
-# CT_ARCH_MOXIE is not set
-# CT_ARCH_MSP430 is not set
 # CT_ARCH_NIOS2 is not set
 # CT_ARCH_POWERPC is not set
 # CT_ARCH_PRU is not set
-# CT_ARCH_RISCV is not set
 # CT_ARCH_S390 is not set
 CT_ARCH_SH=y
 # CT_ARCH_SPARC is not set
@@ -156,7 +146,7 @@ CT_ARCH_SH=y
 # CT_ARCH_XTENSA is not set
 CT_ARCH="sh"
 CT_ARCH_CHOICE_KSYM="SH"
-CT_ARCH_CPU="sh4"
+CT_ARCH_CPU=""
 CT_ARCH_SH_SHOW=y
 
 #
@@ -182,7 +172,6 @@ CT_ARCH_SUFFIX=""
 #
 CT_ARCH_REQUIRES_MULTILIB=y
 CT_MULTILIB=y
-# CT_DEMULTILIB is not set
 CT_ARCH_SUPPORTS_BOTH_MMU=y
 CT_ARCH_DEFAULT_HAS_MMU=y
 CT_ARCH_USE_MMU=y
@@ -216,10 +205,6 @@ CT_TARGET_LDFLAGS=""
 #
 # General toolchain options
 #
-CT_FORCE_SYSROOT=y
-CT_USE_SYSROOT=y
-CT_SYSROOT_NAME="sysroot"
-CT_SYSROOT_DIR_PREFIX=""
 CT_WANTS_STATIC_LINK=y
 CT_WANTS_STATIC_LINK_CXX=y
 # CT_STATIC_TOOLCHAIN is not set
@@ -230,16 +215,14 @@ CT_TOOLCHAIN_BUGURL=""
 #
 # Tuple completion and aliasing
 #
-CT_TARGET_VENDOR="multilib"
+CT_TARGET_VENDOR="unknown"
 CT_TARGET_ALIAS_SED_EXPR=""
 CT_TARGET_ALIAS=""
 
 #
 # Toolchain type
 #
-# CT_NATIVE is not set
 CT_CROSS=y
-# CT_CROSS_NATIVE is not set
 # CT_CANADIAN is not set
 CT_TOOLCHAIN_TYPE="cross"
 
@@ -259,102 +242,22 @@ CT_BUILD_SUFFIX=""
 #
 # Operating System
 #
-CT_KERNEL_SUPPORTS_SHARED_LIBS=y
-# CT_KERNEL_BARE_METAL is not set
-CT_KERNEL_LINUX=y
-CT_KERNEL="linux"
-CT_KERNEL_CHOICE_KSYM="LINUX"
-CT_KERNEL_LINUX_SHOW=y
+CT_BARE_METAL=y
+CT_KERNEL_BARE_METAL=y
+# CT_KERNEL_LINUX is not set
+CT_KERNEL="bare-metal"
+CT_KERNEL_CHOICE_KSYM="BARE_METAL"
+CT_KERNEL_BARE_METAL_SHOW=y
 
 #
-# Options for linux
+# Options for bare-metal
 #
-CT_KERNEL_LINUX_PKG_KSYM="LINUX"
-CT_LINUX_DIR_NAME="linux"
-CT_LINUX_USE_WWW_KERNEL_ORG=y
-# CT_LINUX_USE_ORACLE is not set
-CT_LINUX_USE="LINUX"
-CT_LINUX_PKG_NAME="linux"
-CT_LINUX_SRC_RELEASE=y
-# CT_LINUX_SRC_DEVEL is not set
-# CT_LINUX_SRC_CUSTOM is not set
-CT_LINUX_PATCH_GLOBAL=y
-# CT_LINUX_PATCH_BUNDLED is not set
-# CT_LINUX_PATCH_LOCAL is not set
-# CT_LINUX_PATCH_BUNDLED_LOCAL is not set
-# CT_LINUX_PATCH_LOCAL_BUNDLED is not set
-# CT_LINUX_PATCH_NONE is not set
-CT_LINUX_PATCH_ORDER="global"
-CT_LINUX_V_5_19=y
-# CT_LINUX_V_5_18 is not set
-# CT_LINUX_V_5_17 is not set
-# CT_LINUX_V_5_16 is not set
-# CT_LINUX_V_5_15 is not set
-# CT_LINUX_V_5_14 is not set
-# CT_LINUX_V_5_13 is not set
-# CT_LINUX_V_5_12 is not set
-# CT_LINUX_V_5_11 is not set
-# CT_LINUX_V_5_10 is not set
-# CT_LINUX_V_5_9 is not set
-# CT_LINUX_V_5_8 is not set
-# CT_LINUX_V_5_7 is not set
-# CT_LINUX_V_5_4 is not set
-# CT_LINUX_V_5_3 is not set
-# CT_LINUX_V_5_2 is not set
-# CT_LINUX_V_5_1 is not set
-# CT_LINUX_V_5_0 is not set
-# CT_LINUX_V_4_20 is not set
-# CT_LINUX_V_4_19 is not set
-# CT_LINUX_V_4_18 is not set
-# CT_LINUX_V_4_17 is not set
-# CT_LINUX_V_4_16 is not set
-# CT_LINUX_V_4_15 is not set
-# CT_LINUX_V_4_14 is not set
-# CT_LINUX_V_4_13 is not set
-# CT_LINUX_V_4_12 is not set
-# CT_LINUX_V_4_11 is not set
-# CT_LINUX_V_4_10 is not set
-# CT_LINUX_V_4_9 is not set
-# CT_LINUX_V_4_4 is not set
-# CT_LINUX_V_4_1 is not set
-# CT_LINUX_V_3_16 is not set
-# CT_LINUX_V_3_13 is not set
-# CT_LINUX_V_3_12 is not set
-# CT_LINUX_V_3_10 is not set
-# CT_LINUX_V_3_4 is not set
-# CT_LINUX_V_3_2 is not set
-CT_LINUX_VERSION="5.19.2"
-CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
-CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
-CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
-CT_LINUX_ARCHIVE_FORMATS=".tar.xz .tar.gz"
-CT_LINUX_SIGNATURE_FORMAT="unpacked/.sign"
-CT_LINUX_later_than_5_19=y
-CT_LINUX_5_19_or_later=y
-CT_LINUX_later_than_5_12=y
-CT_LINUX_5_12_or_later=y
-CT_LINUX_later_than_5_5=y
-CT_LINUX_5_5_or_later=y
-CT_LINUX_later_than_5_3=y
-CT_LINUX_5_3_or_later=y
-CT_LINUX_later_than_4_8=y
-CT_LINUX_4_8_or_later=y
-CT_LINUX_later_than_3_7=y
-CT_LINUX_3_7_or_later=y
-CT_LINUX_later_than_3_2=y
-CT_LINUX_3_2_or_later=y
-CT_LINUX_REQUIRE_3_2_or_later=y
-CT_KERNEL_DEP_RSYNC=y
-CT_KERNEL_LINUX_VERBOSITY_0=y
-# CT_KERNEL_LINUX_VERBOSITY_1 is not set
-# CT_KERNEL_LINUX_VERBOSITY_2 is not set
-CT_KERNEL_LINUX_VERBOSE_LEVEL=0
+CT_KERNEL_BARE_METAL_PKG_KSYM=""
 CT_ALL_KERNEL_CHOICES="BARE_METAL LINUX WINDOWS"
 
 #
 # Common kernel options
 #
-CT_SHARED_LIBS=y
 # end of Operating System
 
 #
@@ -372,19 +275,11 @@ CT_BINUTILS_BINUTILS_SHOW=y
 CT_BINUTILS_BINUTILS_PKG_KSYM="BINUTILS"
 CT_BINUTILS_DIR_NAME="binutils"
 CT_BINUTILS_USE_GNU=y
-# CT_BINUTILS_USE_LINARO is not set
 # CT_BINUTILS_USE_ORACLE is not set
 CT_BINUTILS_USE="BINUTILS"
 CT_BINUTILS_PKG_NAME="binutils"
 CT_BINUTILS_SRC_RELEASE=y
 # CT_BINUTILS_SRC_DEVEL is not set
-# CT_BINUTILS_SRC_CUSTOM is not set
-CT_BINUTILS_PATCH_GLOBAL=y
-# CT_BINUTILS_PATCH_BUNDLED is not set
-# CT_BINUTILS_PATCH_LOCAL is not set
-# CT_BINUTILS_PATCH_BUNDLED_LOCAL is not set
-# CT_BINUTILS_PATCH_LOCAL_BUNDLED is not set
-# CT_BINUTILS_PATCH_NONE is not set
 CT_BINUTILS_PATCH_ORDER="global"
 CT_BINUTILS_V_2_39=y
 # CT_BINUTILS_V_2_38 is not set
@@ -418,7 +313,6 @@ CT_BINUTILS_2_26_or_later=y
 #
 # GNU binutils
 #
-CT_BINUTILS_FORCE_LD_BFD_DEFAULT=y
 CT_BINUTILS_LINKER_LD=y
 CT_BINUTILS_LINKERS_LIST="ld"
 CT_BINUTILS_LINKER_DEFAULT="bfd"
@@ -426,131 +320,71 @@ CT_BINUTILS_PLUGINS=y
 CT_BINUTILS_RELRO=m
 CT_BINUTILS_DETERMINISTIC_ARCHIVES=y
 CT_BINUTILS_EXTRA_CONFIG_ARRAY=""
-# CT_BINUTILS_FOR_TARGET is not set
 CT_ALL_BINUTILS_CHOICES="BINUTILS"
 # end of Binary utilities
 
 #
 # C-library
 #
-CT_LIBC_GLIBC=y
-# CT_LIBC_MUSL is not set
-# CT_LIBC_UCLIBC_NG is not set
-CT_LIBC="glibc"
-CT_LIBC_CHOICE_KSYM="GLIBC"
-CT_LIBC_GLIBC_SHOW=y
+CT_LIBC_NEWLIB=y
+# CT_LIBC_NONE is not set
+CT_LIBC="newlib"
+CT_LIBC_CHOICE_KSYM="NEWLIB"
+CT_THREADS="none"
+CT_LIBC_NEWLIB_SHOW=y
 
 #
-# Options for glibc
+# Options for newlib
 #
-CT_LIBC_GLIBC_PKG_KSYM="GLIBC"
-CT_GLIBC_DIR_NAME="glibc"
-CT_GLIBC_USE_GNU=y
-# CT_GLIBC_USE_ORACLE is not set
-CT_GLIBC_USE="GLIBC"
-CT_GLIBC_PKG_NAME="glibc"
-CT_GLIBC_SRC_RELEASE=y
-# CT_GLIBC_SRC_DEVEL is not set
-# CT_GLIBC_SRC_CUSTOM is not set
-CT_GLIBC_PATCH_GLOBAL=y
-# CT_GLIBC_PATCH_BUNDLED is not set
-# CT_GLIBC_PATCH_LOCAL is not set
-# CT_GLIBC_PATCH_BUNDLED_LOCAL is not set
-# CT_GLIBC_PATCH_LOCAL_BUNDLED is not set
-# CT_GLIBC_PATCH_NONE is not set
-CT_GLIBC_PATCH_ORDER="global"
-CT_GLIBC_V_2_36=y
-# CT_GLIBC_V_2_35 is not set
-# CT_GLIBC_V_2_34 is not set
-# CT_GLIBC_V_2_33 is not set
-# CT_GLIBC_V_2_32 is not set
-# CT_GLIBC_V_2_31 is not set
-# CT_GLIBC_V_2_30 is not set
-# CT_GLIBC_V_2_29 is not set
-# CT_GLIBC_V_2_28 is not set
-# CT_GLIBC_V_2_27 is not set
-# CT_GLIBC_V_2_26 is not set
-# CT_GLIBC_V_2_25 is not set
-# CT_GLIBC_V_2_24 is not set
-# CT_GLIBC_V_2_23 is not set
-# CT_GLIBC_V_2_19 is not set
-# CT_GLIBC_V_2_17 is not set
-CT_GLIBC_VERSION="2.36"
-CT_GLIBC_MIRRORS="$(CT_Mirrors GNU glibc)"
-CT_GLIBC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
-CT_GLIBC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
-CT_GLIBC_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
-CT_GLIBC_SIGNATURE_FORMAT="packed/.sig"
-CT_GLIBC_2_36_or_later=y
-CT_GLIBC_2_36_or_older=y
-CT_GLIBC_later_than_2_34=y
-CT_GLIBC_2_34_or_later=y
-CT_GLIBC_later_than_2_32=y
-CT_GLIBC_2_32_or_later=y
-CT_GLIBC_later_than_2_31=y
-CT_GLIBC_2_31_or_later=y
-CT_GLIBC_later_than_2_30=y
-CT_GLIBC_2_30_or_later=y
-CT_GLIBC_later_than_2_29=y
-CT_GLIBC_2_29_or_later=y
-CT_GLIBC_later_than_2_28=y
-CT_GLIBC_2_28_or_later=y
-CT_GLIBC_later_than_2_27=y
-CT_GLIBC_2_27_or_later=y
-CT_GLIBC_later_than_2_26=y
-CT_GLIBC_2_26_or_later=y
-CT_GLIBC_later_than_2_25=y
-CT_GLIBC_2_25_or_later=y
-CT_GLIBC_later_than_2_24=y
-CT_GLIBC_2_24_or_later=y
-CT_GLIBC_later_than_2_23=y
-CT_GLIBC_2_23_or_later=y
-CT_GLIBC_later_than_2_20=y
-CT_GLIBC_2_20_or_later=y
-CT_GLIBC_later_than_2_17=y
-CT_GLIBC_2_17_or_later=y
-CT_GLIBC_later_than_2_14=y
-CT_GLIBC_2_14_or_later=y
-CT_GLIBC_DEP_KERNEL_HEADERS_VERSION=y
-CT_GLIBC_DEP_BINUTILS=y
-CT_GLIBC_DEP_GCC=y
-CT_GLIBC_DEP_PYTHON=y
-CT_THREADS="nptl"
-CT_GLIBC_BUILD_SSP=y
-CT_GLIBC_HAS_LIBIDN_ADDON=y
-# CT_GLIBC_USE_LIBIDN_ADDON is not set
-CT_GLIBC_NO_SPARC_V8=y
-CT_GLIBC_EXTRA_CONFIG_ARRAY=""
-CT_GLIBC_CONFIGPARMS="no-z-defs=yes"
-CT_GLIBC_ENABLE_DEBUG=y
-CT_GLIBC_EXTRA_CFLAGS=""
-# CT_GLIBC_ENABLE_FORTIFIED_BUILD is not set
-# CT_GLIBC_DISABLE_VERSIONING is not set
-CT_GLIBC_OLDEST_ABI=""
-CT_GLIBC_FORCE_UNWIND=y
-# CT_GLIBC_LOCALES is not set
-# CT_GLIBC_KERNEL_VERSION_NONE is not set
-CT_GLIBC_KERNEL_VERSION_AS_HEADERS=y
-# CT_GLIBC_KERNEL_VERSION_CHOSEN is not set
-CT_GLIBC_MIN_KERNEL="5.19.2"
-CT_GLIBC_SSP_DEFAULT=y
-# CT_GLIBC_SSP_NO is not set
-# CT_GLIBC_SSP_YES is not set
-# CT_GLIBC_SSP_ALL is not set
-# CT_GLIBC_SSP_STRONG is not set
-CT_GLIBC_ENABLE_WERROR=y
-# CT_GLIBC_ENABLE_COMMON_FLAG is not set
+CT_LIBC_NEWLIB_PKG_KSYM="NEWLIB"
+CT_NEWLIB_DIR_NAME="newlib"
+CT_NEWLIB_PKG_NAME="newlib"
+CT_NEWLIB_SRC_RELEASE=y
+# CT_NEWLIB_SRC_DEVEL is not set
+CT_NEWLIB_PATCH_ORDER="global"
+CT_NEWLIB_V_4_1=y
+# CT_NEWLIB_V_3_3 is not set
+# CT_NEWLIB_V_3_2 is not set
+# CT_NEWLIB_V_3_1 is not set
+# CT_NEWLIB_V_3_0 is not set
+# CT_NEWLIB_V_2_5 is not set
+CT_NEWLIB_VERSION="4.1.0"
+CT_NEWLIB_MIRRORS="ftp://sourceware.org/pub/newlib"
+CT_NEWLIB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_NEWLIB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_NEWLIB_ARCHIVE_FORMATS=".tar.gz"
+CT_NEWLIB_SIGNATURE_FORMAT=""
+CT_LIBC_NEWLIB_TARGET_CFLAGS=""
+# CT_LIBC_NEWLIB_IO_C99FMT is not set
+# CT_LIBC_NEWLIB_IO_LL is not set
+# CT_LIBC_NEWLIB_IO_FLOAT is not set
+# CT_LIBC_NEWLIB_IO_POS_ARGS is not set
+CT_LIBC_NEWLIB_FVWRITE_IN_STREAMIO=y
+CT_LIBC_NEWLIB_UNBUF_STREAM_OPT=y
+CT_LIBC_NEWLIB_FSEEK_OPTIMIZATION=y
+# CT_LIBC_NEWLIB_DISABLE_SUPPLIED_SYSCALLS is not set
+# CT_LIBC_NEWLIB_REGISTER_FINI is not set
+CT_LIBC_NEWLIB_ATEXIT_DYNAMIC_ALLOC=y
+# CT_LIBC_NEWLIB_GLOBAL_ATEXIT is not set
+# CT_LIBC_NEWLIB_LITE_EXIT is not set
+# CT_LIBC_NEWLIB_REENT_SMALL is not set
+CT_LIBC_NEWLIB_MULTITHREAD=y
+# CT_LIBC_NEWLIB_RETARGETABLE_LOCKING is not set
+# CT_LIBC_NEWLIB_EXTRA_SECTIONS is not set
+CT_LIBC_NEWLIB_WIDE_ORIENT=y
+CT_LIBC_NEWLIB_ENABLE_TARGET_OPTSPACE=y
+# CT_LIBC_NEWLIB_LTO is not set
+# CT_LIBC_NEWLIB_NANO_MALLOC is not set
+# CT_LIBC_NEWLIB_NANO_FORMATTED_IO is not set
+CT_LIBC_NEWLIB_EXTRA_CONFIG_ARRAY=""
 CT_ALL_LIBC_CHOICES="AVR_LIBC GLIBC MINGW_W64 MOXIEBOX MUSL NEWLIB NONE UCLIBC_NG"
-CT_LIBC_SUPPORT_THREADS_ANY=y
-CT_LIBC_SUPPORT_THREADS_NATIVE=y
+CT_LIBC_SUPPORT_THREADS_NONE=y
+CT_LIBC_PROVIDES_CXA_ATEXIT=y
 
 #
 # Common C library options
 #
-CT_THREADS_NATIVE=y
-CT_CREATE_LDSO_CONF=y
-CT_LDSO_CONF_EXTRA_DIRS_ARRAY=""
-CT_LIBC_XLDD=y
+CT_THREADS_NONE=y
 # end of C-library
 
 #
@@ -575,19 +409,11 @@ CT_CC_GCC_SHOW=y
 CT_CC_GCC_PKG_KSYM="GCC"
 CT_GCC_DIR_NAME="gcc"
 CT_GCC_USE_GNU=y
-# CT_GCC_USE_LINARO is not set
 # CT_GCC_USE_ORACLE is not set
 CT_GCC_USE="GCC"
 CT_GCC_PKG_NAME="gcc"
 CT_GCC_SRC_RELEASE=y
 # CT_GCC_SRC_DEVEL is not set
-# CT_GCC_SRC_CUSTOM is not set
-CT_GCC_PATCH_GLOBAL=y
-# CT_GCC_PATCH_BUNDLED is not set
-# CT_GCC_PATCH_LOCAL is not set
-# CT_GCC_PATCH_BUNDLED_LOCAL is not set
-# CT_GCC_PATCH_LOCAL_BUNDLED is not set
-# CT_GCC_PATCH_NONE is not set
 CT_GCC_PATCH_ORDER="global"
 # CT_GCC_V_12 is not set
 # CT_GCC_V_11 is not set
@@ -596,6 +422,8 @@ CT_GCC_V_9=y
 # CT_GCC_V_8 is not set
 # CT_GCC_V_7 is not set
 # CT_GCC_V_6 is not set
+# CT_GCC_V_5 is not set
+# CT_GCC_V_4_9 is not set
 CT_GCC_VERSION="9.5.0"
 CT_GCC_MIRRORS="$(CT_Mirrors GNU gcc/gcc-${CT_GCC_VERSION}) $(CT_Mirrors sourceware gcc/releases/gcc-${CT_GCC_VERSION})"
 CT_GCC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
@@ -616,19 +444,16 @@ CT_GCC_later_than_7=y
 CT_GCC_7_or_later=y
 CT_GCC_later_than_6=y
 CT_GCC_6_or_later=y
-CT_GCC_REQUIRE_6_or_later=y
 CT_GCC_later_than_5=y
 CT_GCC_5_or_later=y
-CT_GCC_REQUIRE_5_or_later=y
 CT_GCC_later_than_4_9=y
 CT_GCC_4_9_or_later=y
-CT_GCC_REQUIRE_4_9_or_later=y
 CT_CC_GCC_ENABLE_PLUGINS=y
 CT_CC_GCC_HAS_LIBMPX=y
 CT_CC_GCC_ENABLE_CXX_FLAGS=""
 CT_CC_GCC_CORE_EXTRA_CONFIG_ARRAY=""
 CT_CC_GCC_EXTRA_CONFIG_ARRAY=""
-CT_CC_GCC_MULTILIB_LIST="m4-nofpu,m4a,m3"
+CT_CC_GCC_MULTILIB_LIST="m2,m2e,m4,m4-single,m4-single-only,m2a,m2a-single"
 CT_CC_GCC_STATIC_LIBSTDCXX=y
 # CT_CC_GCC_SYSTEM_ZLIB is not set
 CT_CC_GCC_CONFIG_TLS=m
@@ -645,17 +470,15 @@ CT_CC_GCC_USE_LTO=y
 CT_CC_GCC_ENABLE_DEFAULT_PIE=y
 CT_CC_GCC_ENABLE_TARGET_OPTSPACE=y
 # CT_CC_GCC_LIBMUDFLAP is not set
-# CT_CC_GCC_LIBGOMP is not set
 # CT_CC_GCC_LIBSSP is not set
 # CT_CC_GCC_LIBQUADMATH is not set
-CT_CC_GCC_LIBSTDCXX_VERBOSE=m
+# CT_CC_GCC_LIBSTDCXX_VERBOSE is not set
 
 #
 # Misc. obscure options.
 #
 CT_CC_CXA_ATEXIT=y
 # CT_CC_GCC_DISABLE_PCH is not set
-CT_CC_GCC_SJLJ_EXCEPTIONS=m
 CT_CC_GCC_LDBL_128=m
 # CT_CC_GCC_BUILD_ID is not set
 CT_CC_GCC_LNK_HASH_STYLE_DEFAULT=y
@@ -674,19 +497,12 @@ CT_ALL_CC_CHOICES="GCC"
 # Additional supported languages:
 #
 CT_CC_LANG_CXX=y
-CT_CC_LANG_FORTRAN=y
-# CT_CC_LANG_ADA is not set
-CT_CC_LANG_D=y
-CT_CC_LANG_OBJC=y
-# CT_CC_LANG_OBJCXX is not set
-# CT_CC_LANG_GOLANG is not set
-CT_CC_LANG_OTHERS=""
+# CT_CC_LANG_FORTRAN is not set
 # end of C compiler
 
 #
 # Debug facilities
 #
-# CT_DEBUG_DUMA is not set
 # CT_DEBUG_GDB is not set
 # CT_DEBUG_LTRACE is not set
 # CT_DEBUG_STRACE is not set
@@ -697,79 +513,28 @@ CT_ALL_DEBUG_CHOICES="DUMA GDB LTRACE STRACE"
 # Companion libraries
 #
 # CT_COMPLIBS_CHECK is not set
-# CT_COMP_LIBS_CLOOG is not set
-CT_COMP_LIBS_EXPAT=y
-CT_COMP_LIBS_EXPAT_PKG_KSYM="EXPAT"
-CT_EXPAT_DIR_NAME="expat"
-CT_EXPAT_PKG_NAME="expat"
-CT_EXPAT_SRC_RELEASE=y
-# CT_EXPAT_SRC_DEVEL is not set
-# CT_EXPAT_SRC_CUSTOM is not set
-CT_EXPAT_PATCH_GLOBAL=y
-# CT_EXPAT_PATCH_BUNDLED is not set
-# CT_EXPAT_PATCH_LOCAL is not set
-# CT_EXPAT_PATCH_BUNDLED_LOCAL is not set
-# CT_EXPAT_PATCH_LOCAL_BUNDLED is not set
-# CT_EXPAT_PATCH_NONE is not set
-CT_EXPAT_PATCH_ORDER="global"
-CT_EXPAT_V_2_4=y
-CT_EXPAT_VERSION="2.4.1"
-CT_EXPAT_MIRRORS="http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION} https://github.com/libexpat/libexpat/releases/download/R_${CT_EXPAT_VERSION//./_}"
-CT_EXPAT_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
-CT_EXPAT_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
-CT_EXPAT_ARCHIVE_FORMATS=".tar.xz .tar.lz .tar.bz2 .tar.gz"
-CT_EXPAT_SIGNATURE_FORMAT=""
-CT_COMP_LIBS_GETTEXT=y
-CT_COMP_LIBS_GETTEXT_PKG_KSYM="GETTEXT"
-CT_GETTEXT_DIR_NAME="gettext"
-CT_GETTEXT_PKG_NAME="gettext"
-CT_GETTEXT_SRC_RELEASE=y
-# CT_GETTEXT_SRC_DEVEL is not set
-# CT_GETTEXT_SRC_CUSTOM is not set
-CT_GETTEXT_PATCH_GLOBAL=y
-# CT_GETTEXT_PATCH_BUNDLED is not set
-# CT_GETTEXT_PATCH_LOCAL is not set
-# CT_GETTEXT_PATCH_BUNDLED_LOCAL is not set
-# CT_GETTEXT_PATCH_LOCAL_BUNDLED is not set
-# CT_GETTEXT_PATCH_NONE is not set
-CT_GETTEXT_PATCH_ORDER="global"
-CT_GETTEXT_V_0_21=y
-# CT_GETTEXT_V_0_20_1 is not set
-# CT_GETTEXT_V_0_19_8_1 is not set
-CT_GETTEXT_VERSION="0.21"
-CT_GETTEXT_MIRRORS="$(CT_Mirrors GNU gettext)"
-CT_GETTEXT_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
-CT_GETTEXT_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
-CT_GETTEXT_ARCHIVE_FORMATS=".tar.xz .tar.gz"
-CT_GETTEXT_SIGNATURE_FORMAT="packed/.sig"
-CT_GETTEXT_0_21_or_later=y
-CT_GETTEXT_0_21_or_older=y
-CT_GETTEXT_INCOMPATIBLE_WITH_UCLIBC_NG=y
-
-#
-# This version of gettext is not compatible with uClibc-NG. Select
-#
-
-#
-# a different version if uClibc-NG is used on the target or (in a
-#
-
-#
-# Canadian cross build) on the host.
-#
+CT_COMP_LIBS_CLOOG=y
+CT_COMP_LIBS_CLOOG_PKG_KSYM="CLOOG"
+CT_CLOOG_DIR_NAME="cloog"
+CT_CLOOG_PKG_NAME="cloog"
+CT_CLOOG_SRC_RELEASE=y
+# CT_CLOOG_SRC_DEVEL is not set
+CT_CLOOG_PATCH_ORDER="global"
+CT_CLOOG_V_0_18_4=y
+CT_CLOOG_VERSION="0.18.4"
+CT_CLOOG_MIRRORS="http://www.bastoul.net/cloog/pages/download"
+CT_CLOOG_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_CLOOG_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_CLOOG_ARCHIVE_FORMATS=".tar.gz"
+CT_CLOOG_SIGNATURE_FORMAT=""
+# CT_COMP_LIBS_EXPAT is not set
+# CT_COMP_LIBS_GETTEXT is not set
 CT_COMP_LIBS_GMP=y
 CT_COMP_LIBS_GMP_PKG_KSYM="GMP"
 CT_GMP_DIR_NAME="gmp"
 CT_GMP_PKG_NAME="gmp"
 CT_GMP_SRC_RELEASE=y
 # CT_GMP_SRC_DEVEL is not set
-# CT_GMP_SRC_CUSTOM is not set
-CT_GMP_PATCH_GLOBAL=y
-# CT_GMP_PATCH_BUNDLED is not set
-# CT_GMP_PATCH_LOCAL is not set
-# CT_GMP_PATCH_BUNDLED_LOCAL is not set
-# CT_GMP_PATCH_LOCAL_BUNDLED is not set
-# CT_GMP_PATCH_NONE is not set
 CT_GMP_PATCH_ORDER="global"
 CT_GMP_V_6_2=y
 # CT_GMP_V_6_1 is not set
@@ -785,15 +550,8 @@ CT_ISL_DIR_NAME="isl"
 CT_ISL_PKG_NAME="isl"
 CT_ISL_SRC_RELEASE=y
 # CT_ISL_SRC_DEVEL is not set
-# CT_ISL_SRC_CUSTOM is not set
-CT_ISL_PATCH_GLOBAL=y
-# CT_ISL_PATCH_BUNDLED is not set
-# CT_ISL_PATCH_LOCAL is not set
-# CT_ISL_PATCH_BUNDLED_LOCAL is not set
-# CT_ISL_PATCH_LOCAL_BUNDLED is not set
-# CT_ISL_PATCH_NONE is not set
 CT_ISL_PATCH_ORDER="global"
-CT_ISL_V_0_24=y
+# CT_ISL_V_0_24 is not set
 # CT_ISL_V_0_23 is not set
 # CT_ISL_V_0_22 is not set
 # CT_ISL_V_0_21 is not set
@@ -802,53 +560,25 @@ CT_ISL_V_0_24=y
 # CT_ISL_V_0_18 is not set
 # CT_ISL_V_0_17 is not set
 # CT_ISL_V_0_16 is not set
-# CT_ISL_V_0_15 is not set
-CT_ISL_VERSION="0.24"
+CT_ISL_V_0_15=y
+CT_ISL_VERSION="0.15"
 CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
 CT_ISL_SIGNATURE_FORMAT=""
-CT_ISL_later_than_0_18=y
-CT_ISL_0_18_or_later=y
-CT_ISL_later_than_0_15=y
+CT_ISL_0_18_or_older=y
+CT_ISL_older_than_0_18=y
 CT_ISL_0_15_or_later=y
+CT_ISL_0_15_or_older=y
 # CT_COMP_LIBS_LIBELF is not set
-CT_COMP_LIBS_LIBICONV=y
-CT_COMP_LIBS_LIBICONV_PKG_KSYM="LIBICONV"
-CT_LIBICONV_DIR_NAME="libiconv"
-CT_LIBICONV_PKG_NAME="libiconv"
-CT_LIBICONV_SRC_RELEASE=y
-# CT_LIBICONV_SRC_DEVEL is not set
-# CT_LIBICONV_SRC_CUSTOM is not set
-CT_LIBICONV_PATCH_GLOBAL=y
-# CT_LIBICONV_PATCH_BUNDLED is not set
-# CT_LIBICONV_PATCH_LOCAL is not set
-# CT_LIBICONV_PATCH_BUNDLED_LOCAL is not set
-# CT_LIBICONV_PATCH_LOCAL_BUNDLED is not set
-# CT_LIBICONV_PATCH_NONE is not set
-CT_LIBICONV_PATCH_ORDER="global"
-CT_LIBICONV_V_1_16=y
-# CT_LIBICONV_V_1_15 is not set
-CT_LIBICONV_VERSION="1.16"
-CT_LIBICONV_MIRRORS="$(CT_Mirrors GNU libiconv)"
-CT_LIBICONV_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
-CT_LIBICONV_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
-CT_LIBICONV_ARCHIVE_FORMATS=".tar.gz"
-CT_LIBICONV_SIGNATURE_FORMAT="packed/.sig"
+# CT_COMP_LIBS_LIBICONV is not set
 CT_COMP_LIBS_MPC=y
 CT_COMP_LIBS_MPC_PKG_KSYM="MPC"
 CT_MPC_DIR_NAME="mpc"
 CT_MPC_PKG_NAME="mpc"
 CT_MPC_SRC_RELEASE=y
 # CT_MPC_SRC_DEVEL is not set
-# CT_MPC_SRC_CUSTOM is not set
-CT_MPC_PATCH_GLOBAL=y
-# CT_MPC_PATCH_BUNDLED is not set
-# CT_MPC_PATCH_LOCAL is not set
-# CT_MPC_PATCH_BUNDLED_LOCAL is not set
-# CT_MPC_PATCH_LOCAL_BUNDLED is not set
-# CT_MPC_PATCH_NONE is not set
 CT_MPC_PATCH_ORDER="global"
 CT_MPC_V_1_2=y
 # CT_MPC_V_1_1 is not set
@@ -867,13 +597,6 @@ CT_MPFR_DIR_NAME="mpfr"
 CT_MPFR_PKG_NAME="mpfr"
 CT_MPFR_SRC_RELEASE=y
 # CT_MPFR_SRC_DEVEL is not set
-# CT_MPFR_SRC_CUSTOM is not set
-CT_MPFR_PATCH_GLOBAL=y
-# CT_MPFR_PATCH_BUNDLED is not set
-# CT_MPFR_PATCH_LOCAL is not set
-# CT_MPFR_PATCH_BUNDLED_LOCAL is not set
-# CT_MPFR_PATCH_LOCAL_BUNDLED is not set
-# CT_MPFR_PATCH_NONE is not set
 CT_MPFR_PATCH_ORDER="global"
 CT_MPFR_V_4_1=y
 # CT_MPFR_V_4_0 is not set
@@ -886,49 +609,14 @@ CT_MPFR_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz .zip"
 CT_MPFR_SIGNATURE_FORMAT="packed/.asc"
 CT_MPFR_later_than_4_0_0=y
 CT_MPFR_4_0_0_or_later=y
-CT_COMP_LIBS_NCURSES=y
-CT_COMP_LIBS_NCURSES_PKG_KSYM="NCURSES"
-CT_NCURSES_DIR_NAME="ncurses"
-CT_NCURSES_PKG_NAME="ncurses"
-CT_NCURSES_SRC_RELEASE=y
-# CT_NCURSES_SRC_DEVEL is not set
-# CT_NCURSES_SRC_CUSTOM is not set
-CT_NCURSES_PATCH_GLOBAL=y
-# CT_NCURSES_PATCH_BUNDLED is not set
-# CT_NCURSES_PATCH_LOCAL is not set
-# CT_NCURSES_PATCH_BUNDLED_LOCAL is not set
-# CT_NCURSES_PATCH_LOCAL_BUNDLED is not set
-# CT_NCURSES_PATCH_NONE is not set
-CT_NCURSES_PATCH_ORDER="global"
-CT_NCURSES_V_6_2=y
-# CT_NCURSES_V_6_1 is not set
-# CT_NCURSES_V_6_0 is not set
-CT_NCURSES_VERSION="6.2"
-CT_NCURSES_MIRRORS="https://invisible-mirror.net/archives/ncurses $(CT_Mirrors GNU ncurses)"
-CT_NCURSES_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
-CT_NCURSES_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
-CT_NCURSES_ARCHIVE_FORMATS=".tar.gz"
-CT_NCURSES_SIGNATURE_FORMAT="packed/.sig"
-CT_NCURSES_NEW_ABI=y
-CT_NCURSES_HOST_CONFIG_ARGS=""
-CT_NCURSES_HOST_DISABLE_DB=y
-CT_NCURSES_HOST_FALLBACKS="linux,xterm,xterm-color,xterm-256color,vt100"
-CT_NCURSES_TARGET_CONFIG_ARGS=""
-# CT_NCURSES_TARGET_DISABLE_DB is not set
-CT_NCURSES_TARGET_FALLBACKS=""
+# CT_COMP_LIBS_NCURSES is not set
+# CT_COMP_LIBS_NEWLIB_NANO is not set
 CT_COMP_LIBS_ZLIB=y
 CT_COMP_LIBS_ZLIB_PKG_KSYM="ZLIB"
 CT_ZLIB_DIR_NAME="zlib"
 CT_ZLIB_PKG_NAME="zlib"
 CT_ZLIB_SRC_RELEASE=y
 # CT_ZLIB_SRC_DEVEL is not set
-# CT_ZLIB_SRC_CUSTOM is not set
-CT_ZLIB_PATCH_GLOBAL=y
-# CT_ZLIB_PATCH_BUNDLED is not set
-# CT_ZLIB_PATCH_LOCAL is not set
-# CT_ZLIB_PATCH_BUNDLED_LOCAL is not set
-# CT_ZLIB_PATCH_LOCAL_BUNDLED is not set
-# CT_ZLIB_PATCH_NONE is not set
 CT_ZLIB_PATCH_ORDER="global"
 CT_ZLIB_V_1_2_12=y
 CT_ZLIB_VERSION="1.2.12"
@@ -938,21 +626,17 @@ CT_ZLIB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ZLIB_ARCHIVE_FORMATS=".tar.xz .tar.gz"
 CT_ZLIB_SIGNATURE_FORMAT="packed/.asc"
 CT_ALL_COMP_LIBS_CHOICES="CLOOG EXPAT GETTEXT GMP GNUPRUMCU ISL LIBELF LIBICONV MPC MPFR NCURSES NEWLIB_NANO PICOLIBC ZLIB"
-CT_LIBICONV_NEEDED=y
-CT_GETTEXT_NEEDED=y
+# CT_LIBICONV_NEEDED is not set
+# CT_GETTEXT_NEEDED is not set
 CT_GMP_NEEDED=y
 CT_MPFR_NEEDED=y
 CT_ISL_NEEDED=y
 CT_MPC_NEEDED=y
-CT_NCURSES_NEEDED=y
 CT_ZLIB_NEEDED=y
-CT_LIBICONV=y
-CT_GETTEXT=y
 CT_GMP=y
 CT_MPFR=y
 CT_ISL=y
 CT_MPC=y
-CT_NCURSES=y
 CT_ZLIB=y
 # end of Companion libraries
 
@@ -969,9 +653,3 @@ CT_ZLIB=y
 # CT_COMP_TOOLS_MAKE is not set
 CT_ALL_COMP_TOOLS_CHOICES="AUTOCONF AUTOMAKE BISON DTC LIBTOOL M4 MAKE"
 # end of Companion tools
-
-#
-# Test suite
-#
-# CT_TEST_SUITE_GCC is not set
-# end of Test suite


### PR DESCRIPTION
SH GCC 9.5 and 12.2 were linux-* and not supporting sh2. We decided to change these compilers to elf-* with sh2 support.

This also causes the removal of fortran as it's not available for elf targets.

refs https://github.com/compiler-explorer/compiler-explorer/issues/94

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>