### PR TITLE
fix: bpf: unset defaulting to PIE

### DIFF
--- a/build/latest/bpf-trunk.config
+++ b/build/latest/bpf-trunk.config
@@ -416,7 +416,7 @@ CT_CC_GCC_LTO_ZSTD=m
 #
 # Settings for libraries running on target
 #
-CT_CC_GCC_ENABLE_DEFAULT_PIE=y
+# CT_CC_GCC_ENABLE_DEFAULT_PIE is not set
 CT_CC_GCC_ENABLE_TARGET_OPTSPACE=y
 # CT_CC_GCC_LIBMUDFLAP is not set
 # CT_CC_GCC_LIBGOMP is not set


### PR DESCRIPTION
ct-ng config has the "default to PIE" set, which is not correct for BPF.

fixes https://github.com/compiler-explorer/compiler-explorer/issues/4517

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>