### PR TITLE
Really use gcc 12.1.0 for the msp430 12.1.0 config

### DIFF
--- a/build/latest/msp430-12.1.0.config
+++ b/build/latest/msp430-12.1.0.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# crosstool-NG 1.25.0.37_618affc Configuration
+# crosstool-NG 1.25.0.162_c116c9a Configuration
 #
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_cxx11=y
@@ -13,12 +13,13 @@ CT_CONFIGURE_has_make_3_81_or_newer=y
 CT_CONFIGURE_has_make_4_0_or_newer=y
 CT_CONFIGURE_has_libtool_2_4_or_newer=y
 CT_CONFIGURE_has_libtoolize_2_4_or_newer=y
-CT_CONFIGURE_has_autoconf_2_65_or_newer=y
-CT_CONFIGURE_has_autoreconf_2_65_or_newer=y
-CT_CONFIGURE_has_automake_1_15_or_newer=y
+CT_CONFIGURE_has_autoconf_2_71_or_newer=y
+CT_CONFIGURE_has_autoreconf_2_71_or_newer=y
+CT_CONFIGURE_has_automake_1_16_or_newer=y
 CT_CONFIGURE_has_gnu_m4_1_4_12_or_newer=y
 CT_CONFIGURE_has_python_3_4_or_newer=y
 CT_CONFIGURE_has_bison_2_7_or_newer=y
+CT_CONFIGURE_has_bison_3_0_4_or_newer=y
 CT_CONFIGURE_has_python=y
 CT_CONFIGURE_has_dtc=y
 CT_CONFIGURE_has_svn=y
@@ -28,7 +29,7 @@ CT_CONFIGURE_has_sha1sum=y
 CT_CONFIGURE_has_sha256sum=y
 CT_CONFIGURE_has_sha512sum=y
 CT_CONFIGURE_has_install_with_strip_program=y
-CT_VERSION="1.25.0.37_618affc"
+CT_VERSION="1.25.0.162_c116c9a"
 CT_VCHECK=""
 CT_CONFIG_VERSION_ENV="4"
 CT_CONFIG_VERSION_CURRENT="4"
@@ -45,6 +46,7 @@ CT_MODULES=y
 # CT_OBSOLETE is not set
 CT_EXPERIMENTAL=y
 # CT_ALLOW_BUILD_AS_ROOT is not set
+# CT_ENABLE_EXPERIMENTAL_BUNDLED_PATCHES is not set
 # CT_DEBUG_CT is not set
 
 #
@@ -63,6 +65,7 @@ CT_INSTALL_LICENSES=y
 CT_PREFIX_DIR_RO=y
 CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
 # CT_STRIP_TARGET_TOOLCHAIN_EXECUTABLES is not set
+# CT_TARBALL_RESULT is not set
 
 #
 # Downloading
@@ -125,7 +128,7 @@ CT_LOG_EXTRA=y
 # CT_LOG_DEBUG is not set
 CT_LOG_LEVEL_MAX="EXTRA"
 # CT_LOG_SEE_TOOLS_WARN is not set
-CT_LOG_PROGRESS_BAR=n
+# CT_LOG_PROGRESS_BAR is not set
 CT_LOG_TO_FILE=y
 CT_LOG_FILE_COMPRESS=y
 # end of Paths and misc options
@@ -137,7 +140,9 @@ CT_LOG_FILE_COMPRESS=y
 # CT_ARCH_ARC is not set
 # CT_ARCH_ARM is not set
 # CT_ARCH_AVR is not set
+# CT_ARCH_BPF is not set
 # CT_ARCH_C6X is not set
+# CT_ARCH_LOONGARCH is not set
 # CT_ARCH_M68K is not set
 # CT_ARCH_MICROBLAZE is not set
 # CT_ARCH_MIPS is not set
@@ -160,7 +165,7 @@ CT_ARCH_MSP430_SHOW=y
 # Options for msp430
 #
 CT_ARCH_MSP430_PKG_KSYM=""
-CT_ALL_ARCH_CHOICES="ALPHA ARC ARM AVR C6X M68K MICROBLAZE MIPS MOXIE MSP430 NIOS2 POWERPC PRU RISCV S390 SH SPARC X86 XTENSA"
+CT_ALL_ARCH_CHOICES="ALPHA ARC ARM AVR BPF C6X LOONGARCH M68K MICROBLAZE MIPS MOXIE MSP430 NIOS2 POWERPC PRU RISCV S390 SH SPARC X86 XTENSA"
 CT_ARCH_SUFFIX=""
 # CT_OMIT_TARGET_VENDOR is not set
 
@@ -275,6 +280,8 @@ CT_BINUTILS_PATCH_GLOBAL=y
 # CT_BINUTILS_PATCH_LOCAL_BUNDLED is not set
 # CT_BINUTILS_PATCH_NONE is not set
 CT_BINUTILS_PATCH_ORDER="global"
+# CT_BINUTILS_V_2_40 is not set
+# CT_BINUTILS_V_2_39 is not set
 CT_BINUTILS_V_2_38=y
 # CT_BINUTILS_V_2_37 is not set
 # CT_BINUTILS_V_2_36 is not set
@@ -294,6 +301,8 @@ CT_BINUTILS_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_BINUTILS_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_BINUTILS_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
 CT_BINUTILS_SIGNATURE_FORMAT="packed/.sig"
+CT_BINUTILS_2_39_or_older=y
+CT_BINUTILS_older_than_2_39=y
 CT_BINUTILS_later_than_2_30=y
 CT_BINUTILS_2_30_or_later=y
 CT_BINUTILS_later_than_2_27=y
@@ -347,7 +356,7 @@ CT_NEWLIB_V_4_1=y
 # CT_NEWLIB_V_3_0 is not set
 # CT_NEWLIB_V_2_5 is not set
 CT_NEWLIB_VERSION="4.1.0"
-CT_NEWLIB_MIRRORS="ftp://sourceware.org/pub/newlib"
+CT_NEWLIB_MIRRORS="https://sourceware.org/pub/newlib"
 CT_NEWLIB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_NEWLIB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_NEWLIB_ARCHIVE_FORMATS=".tar.gz"
@@ -375,7 +384,7 @@ CT_LIBC_NEWLIB_ENABLE_TARGET_OPTSPACE=y
 # CT_LIBC_NEWLIB_NANO_MALLOC is not set
 # CT_LIBC_NEWLIB_NANO_FORMATTED_IO is not set
 CT_LIBC_NEWLIB_EXTRA_CONFIG_ARRAY=""
-CT_ALL_LIBC_CHOICES="AVR_LIBC GLIBC MINGW_W64 MOXIEBOX MUSL NEWLIB NONE UCLIBC_NG"
+CT_ALL_LIBC_CHOICES="AVR_LIBC GLIBC MINGW_W64 MOXIEBOX MUSL NEWLIB NONE PICOLIBC UCLIBC_NG"
 CT_LIBC_SUPPORT_THREADS_NONE=y
 CT_LIBC_PROVIDES_CXA_ATEXIT=y
 
@@ -393,6 +402,7 @@ CT_CC_SUPPORT_CXX=y
 CT_CC_SUPPORT_FORTRAN=y
 CT_CC_SUPPORT_ADA=y
 CT_CC_SUPPORT_D=y
+CT_CC_SUPPORT_JIT=y
 CT_CC_SUPPORT_OBJC=y
 CT_CC_SUPPORT_OBJCXX=y
 CT_CC_SUPPORT_GOLANG=y
@@ -411,9 +421,19 @@ CT_GCC_USE_GNU=y
 # CT_GCC_USE_ORACLE is not set
 CT_GCC_USE="GCC"
 CT_GCC_PKG_NAME="gcc"
-CT_GCC_SRC_RELEASE=y
-# CT_GCC_SRC_DEVEL is not set
+# CT_GCC_SRC_RELEASE is not set
+CT_GCC_SRC_DEVEL=y
 # CT_GCC_SRC_CUSTOM is not set
+CT_GCC_DEVEL_VCS_git=y
+# CT_GCC_DEVEL_VCS_svn is not set
+# CT_GCC_DEVEL_VCS_hg is not set
+# CT_GCC_DEVEL_VCS_cvs is not set
+CT_GCC_DEVEL_VCS="git"
+CT_GCC_DEVEL_URL="git://gcc.gnu.org/git/gcc.git"
+CT_GCC_DEVEL_BRANCH="releases/gcc-12.1.0"
+CT_GCC_DEVEL_REVISION=""
+CT_GCC_DEVEL_SUBDIR=""
+CT_GCC_DEVEL_BOOTSTRAP=""
 CT_GCC_PATCH_GLOBAL=y
 # CT_GCC_PATCH_BUNDLED is not set
 # CT_GCC_PATCH_LOCAL is not set
@@ -421,6 +441,7 @@ CT_GCC_PATCH_GLOBAL=y
 # CT_GCC_PATCH_LOCAL_BUNDLED is not set
 # CT_GCC_PATCH_NONE is not set
 CT_GCC_PATCH_ORDER="global"
+# CT_GCC_VERY_NEW is not set
 CT_GCC_V_12=y
 # CT_GCC_V_11 is not set
 # CT_GCC_V_10 is not set
@@ -430,7 +451,7 @@ CT_GCC_V_12=y
 # CT_GCC_V_6 is not set
 # CT_GCC_V_5 is not set
 # CT_GCC_V_4_9 is not set
-CT_GCC_VERSION="12.1.0"
+CT_GCC_VERSION="12.2.0"
 CT_GCC_MIRRORS="$(CT_Mirrors GNU gcc/gcc-${CT_GCC_VERSION}) $(CT_Mirrors sourceware gcc/releases/gcc-${CT_GCC_VERSION})"
 CT_GCC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GCC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -473,6 +494,7 @@ CT_CC_GCC_LTO_ZSTD=m
 #
 # Settings for libraries running on target
 #
+# CT_CC_GCC_ENABLE_DEFAULT_PIE is not set
 CT_CC_GCC_ENABLE_TARGET_OPTSPACE=y
 # CT_CC_GCC_LIBMUDFLAP is not set
 # CT_CC_GCC_LIBSSP is not set
@@ -503,6 +525,7 @@ CT_ALL_CC_CHOICES="GCC"
 #
 # CT_CC_LANG_CXX is not set
 # CT_CC_LANG_FORTRAN is not set
+# CT_CC_LANG_JIT is not set
 CT_CC_LANG_OTHERS=""
 # end of C compiler
 
@@ -534,8 +557,8 @@ CT_EXPAT_PATCH_GLOBAL=y
 # CT_EXPAT_PATCH_LOCAL_BUNDLED is not set
 # CT_EXPAT_PATCH_NONE is not set
 CT_EXPAT_PATCH_ORDER="global"
-CT_EXPAT_V_2_4=y
-CT_EXPAT_VERSION="2.4.1"
+CT_EXPAT_V_2_5=y
+CT_EXPAT_VERSION="2.5.0"
 CT_EXPAT_MIRRORS="http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION} https://github.com/libexpat/libexpat/releases/download/R_${CT_EXPAT_VERSION//./_}"
 CT_EXPAT_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_EXPAT_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -578,6 +601,8 @@ CT_ISL_PATCH_GLOBAL=y
 # CT_ISL_PATCH_LOCAL_BUNDLED is not set
 # CT_ISL_PATCH_NONE is not set
 CT_ISL_PATCH_ORDER="global"
+# CT_ISL_V_0_26 is not set
+# CT_ISL_V_0_25 is not set
 CT_ISL_V_0_24=y
 # CT_ISL_V_0_23 is not set
 # CT_ISL_V_0_22 is not set
@@ -695,14 +720,35 @@ CT_ZLIB_PATCH_GLOBAL=y
 # CT_ZLIB_PATCH_LOCAL_BUNDLED is not set
 # CT_ZLIB_PATCH_NONE is not set
 CT_ZLIB_PATCH_ORDER="global"
-CT_ZLIB_V_1_2_12=y
-CT_ZLIB_VERSION="1.2.12"
-CT_ZLIB_MIRRORS="http://downloads.sourceforge.net/project/libpng/zlib/${CT_ZLIB_VERSION} https://www.zlib.net/"
+CT_ZLIB_V_1_2_13=y
+CT_ZLIB_VERSION="1.2.13"
+CT_ZLIB_MIRRORS="https://github.com/madler/zlib/releases/download/v${CT_ZLIB_VERSION} https://www.zlib.net/"
 CT_ZLIB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ZLIB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ZLIB_ARCHIVE_FORMATS=".tar.xz .tar.gz"
 CT_ZLIB_SIGNATURE_FORMAT="packed/.asc"
-CT_ALL_COMP_LIBS_CHOICES="CLOOG EXPAT GETTEXT GMP GNUPRUMCU ISL LIBELF LIBICONV MPC MPFR NCURSES NEWLIB_NANO PICOLIBC ZLIB"
+CT_COMP_LIBS_ZSTD=y
+CT_COMP_LIBS_ZSTD_PKG_KSYM="ZSTD"
+CT_ZSTD_DIR_NAME="zstd"
+CT_ZSTD_PKG_NAME="zstd"
+CT_ZSTD_SRC_RELEASE=y
+# CT_ZSTD_SRC_DEVEL is not set
+# CT_ZSTD_SRC_CUSTOM is not set
+CT_ZSTD_PATCH_GLOBAL=y
+# CT_ZSTD_PATCH_BUNDLED is not set
+# CT_ZSTD_PATCH_LOCAL is not set
+# CT_ZSTD_PATCH_BUNDLED_LOCAL is not set
+# CT_ZSTD_PATCH_LOCAL_BUNDLED is not set
+# CT_ZSTD_PATCH_NONE is not set
+CT_ZSTD_PATCH_ORDER="global"
+CT_ZSTD_V_1_5_2=y
+CT_ZSTD_VERSION="1.5.2"
+CT_ZSTD_MIRRORS="https://github.com/facebook/zstd/releases/download/v${CT_ZSTD_VERSION} https://www.zstd.net/"
+CT_ZSTD_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_ZSTD_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_ZSTD_ARCHIVE_FORMATS=".tar.gz"
+CT_ZSTD_SIGNATURE_FORMAT="packed/.sig"
+CT_ALL_COMP_LIBS_CHOICES="CLOOG EXPAT GETTEXT GMP GNUPRUMCU ISL LIBELF LIBICONV MPC MPFR NCURSES NEWLIB_NANO PICOLIBC ZLIB ZSTD"
 # CT_LIBICONV_NEEDED is not set
 # CT_GETTEXT_NEEDED is not set
 CT_GMP_NEEDED=y
@@ -710,11 +756,13 @@ CT_MPFR_NEEDED=y
 CT_ISL_NEEDED=y
 CT_MPC_NEEDED=y
 CT_ZLIB_NEEDED=y
+CT_ZSTD_NEEDED=y
 CT_GMP=y
 CT_MPFR=y
 CT_ISL=y
 CT_MPC=y
 CT_ZLIB=y
+CT_ZSTD=y
 # end of Companion libraries
 
 #


### PR DESCRIPTION
The file was incorrectly using 12.2.

refs https://github.com/compiler-explorer/compiler-explorer/issues/5004

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>