### PR TITLE
vax: Update build script

### DIFF
--- a/build/build-vax-netbsd.sh
+++ b/build/build-vax-netbsd.sh
@@ -1,75 +1,134 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -exuo pipefail
+set -e
 
-## This script uses NetBSD script to build the cross gcc, and will only use what
-## they are using, which is fixed and not configurable. Currently, it's 10.4.0
-VERSION="$1"
+#
+# Global variables.
+#
+s3=
+nb_requested_timestamp=$(date '+%s')
+nb_arch=vax
+nb_mach=vax
+nb_git="https://github.com/NetBSD/src.git"
+gcc_target=vax--netbsdelf
+gcc_dir=gcc.old
+declare -a build_vars
+workdir=/opt/build-netbsd.$$
+src_checkout_dir="${workdir}/src"
+reldir="${workdir}/rel"
+destdir="${workdir}/dest"
+tooldir="${workdir}/tools"
 
-NETBSD_GCC_VERSION=$(curl -q https://raw.githubusercontent.com/NetBSD/src/trunk/external/gpl3/gcc/dist/gcc/BASE-VER)
-[ -z "${NETBSD_GCC_VERSION}" ] && exit 1
+#
+# Parse `--new`, `--old`, `--s3`, `--timestamp` and `--force-output`.
+#
+# new/old: Refers to "new" GCC and "old" GCC in the context of NetBSD.
+# Currently "old": 10.x (default)
+#           "new": 12.x
+#
+# Use "--timestamp 1680300000" to rebuild the same 10.4.0 compiler as the one we
+# have installed in
+# https://github.com/compiler-explorer/compiler-explorer/issues/4783
 
-if [[ "${VERSION}" != "${NETBSD_GCC_VERSION}" ]]; then
-    echo "Only ${NETBSD_GCC_VERSION} supported as currently used in NetBSD"
-    exit 255
+if ! parsed_opts=$(getopt -o ons:t:f:h --long old,new,s3:,timestamp:,force-output:,help -n "${0}" -- "$@"); then
+	echo "Error parsing options." >&2
+	exit 1
 fi
 
-TARGET=vax-netbsdelf
+eval set -- "${parsed_opts}"
+while :; do
+	case "${1}" in
+		-o | --old)
+			gcc_dir=gcc.old
+			build_vars=()
+			shift
+			;;
 
-OUTPUT=/home/gcc-user/${TARGET}-gcc-${VERSION}.tar.xz
+		-n | --new)
+			gcc_dir=gcc
+			build_vars=( "-V" "HAVE_GCC=12" )
+			shift
+			;;
 
-ARG2=${2:-}
-FULLNAME=${TARGET}-gcc-${VERSION}
-if [[ $ARG2 =~ s3:// ]]; then
-    S3OUTPUT=$ARG2
-else
-    S3OUTPUT=""
-    if [[ -d "${ARG2}" ]]; then
-        OUTPUT="${ARG2}/${FULLNAME}.tar.xz"
-    else
-        OUTPUT=${2-/home/gcc-user/${FULLNAME}.tar.xz}
-    fi
-fi
+		-s | --s3)
+			s3="${2}"
+			shift 2
+			;;
 
-## Build script from jbglaw https://github.com/compiler-explorer/compiler-explorer/issues/4783#issuecomment-1447028024
-## with minor tweaks
-GIT_NETBSD_SRC=NetBSD-src
-WORKDIR=/opt/build-netbsd
-RELEASEDIR="${WORKDIR}/rel"
-DESTDIR="${WORKDIR}/dest"
-TOOLDIR="${WORKDIR}/tools"
+		-t | --timestamp)
+			nb_requested_timestamp="${2}"
+			shift 2
+			;;
 
-FINAL_ROOT="${WORKDIR}/gcc-${VERSION}"
-FINAL_SYSROOT="${FINAL_ROOT}/vax--netbsdelf-sysroot"
+		-f | --force-output)
+			forced_output_filename="${2}"
+			shift 2
+			;;
 
-NB_ARCH=vax
-NB_MACHINE=vax
+		--)
+			shift
+			break
+			;;
 
-rm -rf "${WORKDIR}"
-mkdir -p "${WORKDIR}"
-pushd "${WORKDIR}"
-    git clone -q --depth 1 --single-branch https://github.com/NetBSD/src.git "${GIT_NETBSD_SRC}"
-	pushd "${GIT_NETBSD_SRC}"
-		./build.sh -P -U -m "${NB_MACHINE}" -a "${NB_ARCH}" -E -D "${DESTDIR}" -R "${RELEASEDIR}" -T "${TOOLDIR}" tools libs
-	popd
+		-h | --help | *)
+			echo "${0} <--old | --new> <--s3 s3://...> <--timestamp 1699485114> <--force-output /path/to/gcc-out.tar.xz>" >&2
+			echo "Defaults are: --old, current timestamp, no s3 upload, output tarball in workdir" >&2
+			echo >&2
+			echo "Option --old               will build the current NetBSD compiler" >&2
+			echo "Option --new               will set HAVE_GCC=12 (which is correct while the 10.x -> 12.x transition is on the way) to build the experimental compiler" >&2
+			echo "Option --timestamp <epoch> will checkout the most recent commit older or equal than the supplied timestamp" >&2
+			echo "Option --force-output <f>  will create the compiler tarball (.xz) with the supplied filename" >&2
+			exit 1
+			;;
+	esac
+done
 
-    ## Move stuff around
-    mv tools "${FINAL_ROOT}"
-    mv dest  "${FINAL_SYSROOT}"
+#
+# Now build the compiler and create a tarball.
+#
 
-    ## Sanity check
-	printf 'int main(int argc, char *argv[]) {return argc*4+3;}\n' > t.c
-	"${FINAL_ROOT}/bin/vax--netbsdelf-gcc" --sysroot="${FINAL_SYSROOT}" -o t t.c
-	"${FINAL_ROOT}/bin/vax--netbsdelf-objdump" -Sw t
+# Prepare a clean workdir, fetch sources, get GCC version number and build it.
+rm -rf "${workdir}"
+mkdir -p "${workdir}"
+git clone -q "${nb_git}" "${src_checkout_dir}"
+pushd "${src_checkout_dir}"
+	# Do checkout based on supplied/current timestamp, notice actual commit timestamp.
+	git_rev="$(git rev-list -n 1 --before="@${nb_requested_timestamp}" trunk)"
+	git checkout "${git_rev}"
+	nb_actual_timestamp="$(git log -1 --format="%as")"
+
+	# Get GCC version number.
+	gcc_version="$(cat "external/gpl3/${gcc_dir}/dist/gcc/BASE-VER")"
+
+	# Build all the Compiler / Libs stuff.
+	./build.sh -P -U "${build_vars[@]}" -m "${nb_mach}" -a "${nb_arch}" -E -D "${destdir}" -R "${reldir}" -T "${tooldir}" tools libs
 popd
-## End of build
 
+# Package newly built compiler.
+gcc_name="gcc-${gcc_target}-${gcc_version}-${nb_actual_timestamp}"
+gcc_tarball="${workdir}/${gcc_name}.tar.xz"
+[ -z "${forced_output_filename}" ] || gcc_tarball="${forced_output_filename}"
+gcc_destdir="${workdir}/${gcc_name}"
+gcc_destdir_sysroot="${gcc_destdir}/${gcc_target}-sysroot"
+mkdir -p "${gcc_destdir}"
+mkdir -p "${gcc_destdir_sysroot}"
+(cd "${tooldir}" && tar cf - .) | (cd "${gcc_destdir}" && tar xf -)
+(cd "${destdir}" && tar cf - .) | (cd "${gcc_destdir_sysroot}" && tar xf -)
+
+# Try to use this new compiler.
+printf 'int main(int argc, char *argv[]) {return argc*4+3;}\n' > t.c
+"${gcc_destdir}/bin/${gcc_target}-gcc" --sysroot="${gcc_destdir_sysroot}" -o t t.c
+"${gcc_destdir}/bin/${gcc_target}-objdump" -Sw t
+
+# Create tarball.
 export XZ_DEFAULTS="-T 0"
-tar Jcf "${OUTPUT}" -C "${WORKDIR}" "gcc-${VERSION}"
+tar Jcf "${gcc_tarball}" -C "${workdir}" "${gcc_name}"
 
-if [[ -n "${S3OUTPUT}" ]]; then
-    aws s3 cp --storage-class REDUCED_REDUNDANCY "${OUTPUT}" "${S3OUTPUT}"
+# Maybe copy to S3 storage.
+if [ -n "${s3}" ]; then
+	aws s3 cp --storage-class REDUCED_REDUNDANCY "${gcc_tarball}" "${s3}"
 fi
 
-echo "ce-build-output:${OUTPUT}"
+# State outcome.
+echo "ce-build-output:${gcc_tarball}"
 echo "ce-build-status:OK"


### PR DESCRIPTION
The script can be used to build arbitrary version based on old/new
GCC (in the context of NetBSD) and an optional timestamp.

Refs https://github.com/compiler-explorer/compiler-explorer/issues/5708

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>
Co-authored-by: Jan-Benedict Glaw <jbglaw@lug-owl.de>